### PR TITLE
Improve editor architecture and contributor workflow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,44 @@
+# Cadle architecture
+
+Cadle is organized around a thin UI layer and framework-independent drawing logic. New behavior should move toward the
+domain modules below instead of increasing the responsibilities of `app.ts` or `shell.ts`.
+
+## Runtime boundaries
+
+- `src/app.ts` — `<cadle-app>` composition root for the SVG editor. It connects controllers to rendering, persistence,
+  and browser events; its public custom-element API must remain stable.
+- `src/shell.ts` — application shell and project/page orchestration.
+- `src/native-draw/` — canonical shape types, document-state validation, geometry, normalization, and legacy migration.
+  Modules here must not depend on UI components or persistence.
+- `src/native-app/` — focused editor use cases and controllers, including history, pointer behavior, circuit analysis,
+  one-wire generation, and export.
+- `src/api/` — persistence gateways for projects and catalogs.
+- `src/elements/`, `src/fields/`, `src/screens/` — custom elements grouped by UI role.
+- `src/shell/` — services used by the application shell, such as routing, presence, catalog state, and styles.
+- `test/` — Node tests for pure domain modules and controllers.
+
+## Dependency direction
+
+```text
+UI elements / app / shell
+          ↓
+controllers and use cases (`native-app`)
+          ↓
+shape and electrical domain (`native-draw`)
+          ↓
+           types
+```
+
+Persistence is invoked by the composition roots after a controller changes state. Pure controllers should not import
+custom elements, browser storage, or rendering code.
+
+## Change guidelines
+
+1. Extract one responsibility at a time from `app.ts` or `shell.ts` behind a small typed API.
+2. Add unit tests for the extracted behavior before moving the next responsibility.
+3. Keep state cloning and invariants at controller boundaries so callers cannot mutate stored state accidentally.
+4. Keep generated files in `www/` out of source refactors; `npm run build` recreates them.
+5. Run `npm run check` before submitting a change.
+
+The next planned editor boundaries are `OneWireController` and `CatalogController`; see `IMPROVEMENT_ROADMAP.md` for
+the product sequence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Cadle
+
+## Getting started
+
+Cadle requires a current Node.js release and npm.
+
+```sh
+npm ci
+npm run check
+```
+
+Use `npm run dev` for a watched browser build. Use `npm run standalone` for the production-style local server or
+`npm run standalone:desktop` for Electron.
+
+## Before opening a pull request
+
+Run the single quality gate:
+
+```sh
+npm run check
+```
+
+It runs the Node test suite, TypeScript without emitting files, and the production Rollup build. Do not commit build
+output created only while validating a source change.
+
+## Where code belongs
+
+- Put shape types, sanitization, and pure geometry in `src/native-draw/`.
+- Put editor controllers and use cases in `src/native-app/`.
+- Keep persistence behind `src/api/` and `src/native-project-data.ts`.
+- Keep custom elements focused on translating events and state into controller calls and rendered templates.
+- Add Node tests for pure logic under `test/`, named after the module they exercise.
+
+Read `ARCHITECTURE.md` before changing `src/app.ts` or `src/shell.ts`. Those files are composition roots; prefer a
+small tested extraction when new behavior would make either one larger.
+
+## Change style
+
+- Keep changes narrow enough to review independently.
+- Preserve the `<cadle-app>` public API unless the change explicitly includes a migration.
+- Keep controller inputs and outputs typed and framework-independent.
+- Clone mutable document state at controller boundaries.
+- Avoid top-level storage or DOM work in domain modules; it makes imports unsafe in tests and tooling.
+- Add or update tests for bug fixes and state transitions.
+
+## Pull-request notes
+
+Explain the user-visible effect, the architectural boundary affected, and the validation performed. Call out schema or
+persistence changes explicitly, including compatibility with existing projects.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "serve-2": "jsproject --serve www --port 4332",
     "generate:manifest": "node generate-manifest.js",
     "build": "npm run generate:manifest && rollup -c",
-    "test": "node --import tsx --test test/**/*.test.ts"
+    "test": "node --import tsx --test test/**/*.test.ts",
+    "typecheck": "tsc --noEmit",
+    "check": "npm test && npm run typecheck && npm run build"
   },
   "keywords": [],
   "author": "",

--- a/src/app.ts
+++ b/src/app.ts
@@ -121,6 +121,9 @@ import {
   type CircuitComponent,
   type BomRow
 } from './native-app/circuit-analysis.js'
+import { DocumentHistory } from './native-app/document-history.js'
+import { ViewportController } from './native-app/viewport-controller.js'
+import { ToolController } from './native-app/tool-controller.js'
 
 type SnapIndicatorKind = 'wall' | 'electrical' | 'onewire'
 type BindingLabelSide = 'left' | 'right' | 'top' | 'bottom'
@@ -287,7 +290,7 @@ const getBindingLabelOffset = (shape: Shape, side: BindingLabelSide): { x: numbe
 export class CadleApp extends LiteElement {
   static styles = [styles]
 
-  #tool: Tool = 'select'
+  #tools = new ToolController()
   #shapes: Shape[] = []
   #selectedId: string | null = null
   #draft: DraftShape | null = null
@@ -299,8 +302,7 @@ export class CadleApp extends LiteElement {
     shapeCenter: Point
     initialOffset: { x: number; y: number }
   } | null = null
-  #history: Snapshot[] = []
-  #historyIndex = -1
+  #history = new DocumentHistory()
   #snap = true
   #stagePointerId: number | null = null
   #paperPreset: PaperPreset = 'a4-landscape'
@@ -327,9 +329,7 @@ export class CadleApp extends LiteElement {
   // Active symbol placement gesture: anchor stays fixed while dragging sets the rotation.
   #symbolPlacement: { anchor: Point; rotation: number } | null = null
   // Zoom & pan state
-  #zoom = 1
-  #panX = 0
-  #panY = 0
+  #viewport = new ViewportController()
   #isPanning = false
   #panStart: { px: number; py: number; panX: number; panY: number } | null = null
   #spaceDown = false
@@ -370,70 +370,6 @@ export class CadleApp extends LiteElement {
   #catalogDialogFolderOptions: string[] = []
   #catalogDialogCategoryOptions: CatalogDialogCategoryOption[] = []
   #catalogDialogReplaceOptions: CatalogDialogReplaceOption[] = []
-
-  #toolFromShellAction(action: string): Tool {
-    switch (action) {
-      case 'draw-wall':
-        return 'wall'
-      case 'draw-door':
-        return 'door'
-      case 'draw-window':
-        return 'window'
-      case 'draw-gate':
-        return 'gate'
-      case 'draw-line':
-      case 'draw-cable':
-        return 'line'
-      case 'draw-onewire':
-        return 'onewire'
-      case 'draw-square':
-        return 'rect'
-      case 'draw-circle':
-        return 'circle'
-      case 'draw-arc':
-        return 'arc'
-      case 'draw-text':
-        return 'text'
-      case 'draw-symbol':
-        return 'symbol'
-      case 'draw':
-        return 'line'
-      case 'resize':
-      case 'select':
-      default:
-        return 'select'
-    }
-  }
-
-  #shellActionFromTool(tool: Tool): string {
-    switch (tool) {
-      case 'wall':
-        return 'draw-wall'
-      case 'door':
-        return 'draw-door'
-      case 'window':
-        return 'draw-window'
-      case 'gate':
-        return 'draw-gate'
-      case 'line':
-        return 'draw-line'
-      case 'onewire':
-        return 'draw-onewire'
-      case 'rect':
-        return 'draw-square'
-      case 'circle':
-        return 'draw-circle'
-      case 'arc':
-        return 'draw-arc'
-      case 'text':
-        return 'draw-text'
-      case 'symbol':
-        return 'draw-symbol'
-      case 'select':
-      default:
-        return 'select'
-    }
-  }
 
   connectedCallback() {
     super.connectedCallback()
@@ -532,7 +468,7 @@ export class CadleApp extends LiteElement {
   }
 
   #onShellAction = (action: string) => {
-    const nextTool = this.#toolFromShellAction(action ?? '')
+    const nextTool = this.#tools.toolForShellAction(action ?? '')
     this.#activateTool(nextTool)
   }
 
@@ -596,7 +532,7 @@ export class CadleApp extends LiteElement {
       metadata
     }
     this.#symbolPreviewPoint = null
-    this.#tool = 'symbol'
+    this.#tools.select('symbol')
     this.#draft = null
     this.#render()
   }
@@ -1146,8 +1082,7 @@ export class CadleApp extends LiteElement {
   }
 
   async #initialize() {
-    this.#history = []
-    this.#historyIndex = -1
+    this.#history.reset()
     this.#draft = null
     this.#drag = null
     this.#selectedId = null
@@ -1274,20 +1209,15 @@ export class CadleApp extends LiteElement {
   }
 
   #pushHistory(persist = true, replaceCurrent = false) {
-    const snapshot: Snapshot = {
-      shapes: cloneShapes(this.#shapes),
-      selectedId: this.#selectedId,
-      worldWidth: this.#worldWidth,
-      worldHeight: this.#worldHeight
-    }
-    if (replaceCurrent && this.#historyIndex >= 0) {
-      this.#history[this.#historyIndex] = snapshot
-      if (persist) this.#persist()
-      return
-    }
-    this.#history = this.#history.slice(0, this.#historyIndex + 1)
-    this.#history.push(snapshot)
-    this.#historyIndex = this.#history.length - 1
+    this.#history.push(
+      {
+        shapes: this.#shapes,
+        selectedId: this.#selectedId,
+        worldWidth: this.#worldWidth,
+        worldHeight: this.#worldHeight
+      },
+      replaceCurrent
+    )
     if (persist) this.#persist()
   }
 
@@ -1327,15 +1257,13 @@ export class CadleApp extends LiteElement {
   }
 
   #undo() {
-    if (this.#historyIndex <= 0) return
-    this.#historyIndex -= 1
-    this.#restoreSnapshot(this.#history[this.#historyIndex])
+    const snapshot = this.#history.undo()
+    if (snapshot) this.#restoreSnapshot(snapshot)
   }
 
   #redo() {
-    if (this.#historyIndex >= this.#history.length - 1) return
-    this.#historyIndex += 1
-    this.#restoreSnapshot(this.#history[this.#historyIndex])
+    const snapshot = this.#history.redo()
+    if (snapshot) this.#restoreSnapshot(snapshot)
   }
 
   #snapPoint(point: Point): Point {
@@ -1354,7 +1282,7 @@ export class CadleApp extends LiteElement {
     // Convert screen → world via our explicit pan/zoom transform
     const screenX = event.clientX - rect.left
     const screenY = event.clientY - rect.top
-    const worldPt = this.#screenToWorld(screenX, screenY)
+    const worldPt = this.#viewport.screenToWorld({ x: screenX, y: screenY })
     return {
       x: Math.max(0, Math.min(this.#worldWidth, worldPt.x)),
       y: Math.max(0, Math.min(this.#worldHeight, worldPt.y))
@@ -1363,27 +1291,9 @@ export class CadleApp extends LiteElement {
 
   // ── Zoom & pan helpers ────────────────────────────────────────────────────
 
-  #clampZoom(z: number): number {
-    return Math.max(0.1, Math.min(8, z))
-  }
-
   // Zoom centred on a screen-space point (px, py are relative to the panel element).
   #zoomAt(px: number, py: number, factor: number) {
-    const next = this.#clampZoom(this.#zoom * factor)
-    if (next === this.#zoom) return
-    // Keep the point under the cursor stationary: adjust pan so world-point stays the same.
-    this.#panX = px - (px - this.#panX) * (next / this.#zoom)
-    this.#panY = py - (py - this.#panY) * (next / this.#zoom)
-    this.#zoom = next
-    this.#render()
-  }
-
-  // Convert a screen-space event point (relative to panel) to world coordinates.
-  #screenToWorld(screenX: number, screenY: number): Point {
-    return {
-      x: (screenX - this.#panX) / this.#zoom,
-      y: (screenY - this.#panY) / this.#zoom
-    }
+    if (this.#viewport.zoomAt({ x: px, y: py }, factor)) this.#render()
   }
 
   #autoCenterView() {
@@ -1395,15 +1305,10 @@ export class CadleApp extends LiteElement {
 
     // Fit the page (world) so the safe-area dashed boundary, grid and content
     // are shown coherently — like a print preview.
-    const margin = 12
-    const availableWidth = rect.width - margin * 2
-    const availableHeight = rect.height - margin * 2
-    const zoomX = availableWidth / this.#worldWidth
-    const zoomY = availableHeight / this.#worldHeight
-    this.#zoom = this.#clampZoom(Math.min(1, zoomX, zoomY))
-
-    this.#panX = (rect.width - this.#worldWidth * this.#zoom) / 2
-    this.#panY = (rect.height - this.#worldHeight * this.#zoom) / 2
+    this.#viewport.fit(
+      { width: rect.width, height: rect.height },
+      { width: this.#worldWidth, height: this.#worldHeight }
+    )
   }
 
   #onWheel = (event: WheelEvent) => {
@@ -1470,8 +1375,7 @@ export class CadleApp extends LiteElement {
       this.#zoomAt(px, py, factor)
     } else {
       // Scroll/pan
-      this.#panX -= event.deltaX
-      this.#panY -= event.deltaY
+      this.#viewport.panBy(-event.deltaX, -event.deltaY)
       this.#render()
     }
   }
@@ -1609,7 +1513,7 @@ export class CadleApp extends LiteElement {
     ) {
       return PROJECT_LOGO_SHAPE_ID
     }
-    const tolerance = Math.max(6, 12 / this.#zoom)
+    const tolerance = Math.max(6, 12 / this.#viewport.state.zoom)
     for (let index = this.#shapes.length - 1; index >= 0; index -= 1) {
       const shape = this.#shapes[index]
       if (
@@ -1637,9 +1541,8 @@ export class CadleApp extends LiteElement {
   }
 
   #activateTool(tool: Tool) {
-    if (tool === this.#tool) return
-    this.#tool = tool
-    const shellAction = this.#shellActionFromTool(tool)
+    if (!this.#tools.select(tool)) return
+    const shellAction = this.#tools.shellAction()
     if (window.cadleShell?.action !== shellAction) {
       window.cadleShell.action = shellAction
     }
@@ -1724,7 +1627,7 @@ export class CadleApp extends LiteElement {
 
   #ungroupNativeSelection(): boolean {
     const selectedIds = this.#selectedShapeIds()
-    if (!selectedIds.size) return false
+    if (!selectedIds.length) return false
 
     // First, check if we're ungrouping symbols with catalogShapes
     let unpackedAny = false
@@ -2325,7 +2228,7 @@ export class CadleApp extends LiteElement {
 
   #handleEscapeKey() {
     const action = resolveNativeEscapeAction({
-      tool: this.#tool,
+      tool: this.#tools.current,
       hasPendingCatalogSymbol: Boolean(this.#pendingCatalogSymbol),
       hasSymbolPreviewPoint: Boolean(this.#symbolPreviewPoint),
       hasWallChain: Boolean(this.#wallChain),
@@ -2341,7 +2244,7 @@ export class CadleApp extends LiteElement {
       this.#pendingCatalogSymbol = null
       this.#symbolPreviewPoint = null
       this.#symbolPlacement = null
-      this.#tool = 'select'
+      this.#tools.select('select')
       this.#render()
       return
     }
@@ -2377,7 +2280,7 @@ export class CadleApp extends LiteElement {
       return
     }
 
-    if (this.#tool !== 'select') {
+    if (this.#tools.current !== 'select') {
       this.#activateTool('select')
     }
   }
@@ -2523,7 +2426,7 @@ export class CadleApp extends LiteElement {
       const sideByPointer = Math.sign((point.x - closest.x) * nx + (point.y - closest.y) * ny)
       const side = sideByPointer === 0 ? 1 : sideByPointer
       const wallStrokePx = typeof shape.strokeWidth === 'number' ? shape.strokeWidth : 12
-      const wallHalfThickness = wallStrokePx / (2 * Math.max(this.#zoom, 0.1))
+      const wallHalfThickness = wallStrokePx / (2 * Math.max(this.#viewport.state.zoom, 0.1))
       const wallDerivedMinGap = wallHalfThickness * (5 / 6)
       const wallEdgeOffset = Math.max(symbolHalfExtent * WALL_EDGE_OFFSET_FACTOR, wallDerivedMinGap)
       const centerOffset = wallHalfThickness + symbolHalfExtent + wallEdgeOffset
@@ -2581,13 +2484,18 @@ export class CadleApp extends LiteElement {
   }
 
   #shouldShowSnapIndicator(): boolean {
-    if (!this.#snapTarget || !this.#snap || this.#tool === 'select') return false
-    if (this.#tool === 'wall') return Boolean(this.#wallChain)
-    if (this.#tool === 'door' || this.#tool === 'window' || this.#tool === 'gate' || this.#tool === 'line') {
+    if (!this.#snapTarget || !this.#snap || this.#tools.current === 'select') return false
+    if (this.#tools.current === 'wall') return Boolean(this.#wallChain)
+    if (
+      this.#tools.current === 'door' ||
+      this.#tools.current === 'window' ||
+      this.#tools.current === 'gate' ||
+      this.#tools.current === 'line'
+    ) {
       return Boolean(this.#draft)
     }
-    if (this.#tool === 'symbol') return Boolean(this.#pendingCatalogSymbol)
-    if (this.#tool === 'onewire') return true
+    if (this.#tools.current === 'symbol') return Boolean(this.#pendingCatalogSymbol)
+    if (this.#tools.current === 'onewire') return true
     return false
   }
 
@@ -3994,11 +3902,12 @@ export class CadleApp extends LiteElement {
 
   render() {
     const selectedShape = this.#shapeById(this.#selectedId)
-    const worldTransform = `translate(${this.#panX} ${this.#panY}) scale(${this.#zoom})`
-    const minorGrid = GRID_SIZE * 2 * this.#zoom
-    const majorGrid = GRID_SIZE * 10 * this.#zoom
+    const { zoom, panX, panY } = this.#viewport.state
+    const worldTransform = `translate(${panX} ${panY}) scale(${zoom})`
+    const minorGrid = GRID_SIZE * 2 * zoom
+    const majorGrid = GRID_SIZE * 10 * zoom
     const gridStyle =
-      `background-position: ${this.#panX}px ${this.#panY}px; ` +
+      `background-position: ${panX}px ${panY}px; ` +
       `background-size: ${minorGrid}px ${minorGrid}px, ${minorGrid}px ${minorGrid}px, ` +
       `${majorGrid}px ${majorGrid}px, ${majorGrid}px ${majorGrid}px`
     const cursor = this.#isPanning || this.#spaceDown ? 'grab' : 'default'
@@ -4343,7 +4252,7 @@ export class CadleApp extends LiteElement {
 
   #previewTemplate() {
     const symbolPreviewShape: SymbolShape | null =
-      this.#tool === 'symbol' && this.#pendingCatalogSymbol && this.#symbolPreviewPoint
+      this.#tools.current === 'symbol' && this.#pendingCatalogSymbol && this.#symbolPreviewPoint
         ? {
             id: '__symbol-preview__',
             kind: 'symbol',
@@ -4387,35 +4296,6 @@ export class CadleApp extends LiteElement {
     this.requestRender()
   }
 
-  #toolLabel(tool: Tool): string {
-    switch (tool) {
-      case 'select':
-        return 'Select'
-      case 'wall':
-        return 'Wall'
-      case 'line':
-        return 'Line'
-      case 'door':
-        return 'Door'
-      case 'window':
-        return 'Window'
-      case 'gate':
-        return 'Gate'
-      case 'rect':
-        return 'Box'
-      case 'circle':
-        return 'Circle'
-      case 'arc':
-        return 'Arc'
-      case 'text':
-        return 'Text'
-      case 'symbol':
-        return 'Symbol'
-      case 'onewire':
-        return `One-wire ${this.#oneWireBindingId}`
-    }
-  }
-
   #nextOneWireBindingId(): string {
     return nextOneWireBindingId(this.#oneWireBindingId, this.#oneWirePreset)
   }
@@ -4445,7 +4325,7 @@ export class CadleApp extends LiteElement {
       if (preset && preset in ONE_WIRE_PRESETS) {
         this.#oneWirePreset = preset
         this.#oneWireMode = 'preset'
-        if (this.#tool !== 'onewire') this.#activateTool('onewire')
+        if (this.#tools.current !== 'onewire') this.#activateTool('onewire')
         else this.#render()
       }
       return
@@ -4457,7 +4337,7 @@ export class CadleApp extends LiteElement {
       if (next === 'breaker' || next === 'switch' || next === 'kamrail' || next === 'load') {
         this.#oneWireMode = 'compose'
         this.#oneWireComposeKind = next
-        if (this.#tool !== 'onewire') this.#activateTool('onewire')
+        if (this.#tools.current !== 'onewire') this.#activateTool('onewire')
         else this.#render()
       }
       return
@@ -4545,7 +4425,7 @@ export class CadleApp extends LiteElement {
     if (preset && preset in ONE_WIRE_PRESETS) {
       this.#oneWirePreset = preset
       this.#oneWireMode = 'preset'
-      if (this.#tool !== 'onewire') this.#activateTool('onewire')
+      if (this.#tools.current !== 'onewire') this.#activateTool('onewire')
       else this.#render()
       return
     }
@@ -4554,7 +4434,7 @@ export class CadleApp extends LiteElement {
     if (compose === 'breaker' || compose === 'switch' || compose === 'kamrail' || compose === 'load') {
       this.#oneWireMode = 'compose'
       this.#oneWireComposeKind = compose
-      if (this.#tool !== 'onewire') this.#activateTool('onewire')
+      if (this.#tools.current !== 'onewire') this.#activateTool('onewire')
       else this.#render()
       return
     }
@@ -4572,13 +4452,13 @@ export class CadleApp extends LiteElement {
         return
       case 'onewire-next':
         this.#advanceOneWireBinding()
-        if (this.#tool !== 'onewire') this.#activateTool('onewire')
+        if (this.#tools.current !== 'onewire') this.#activateTool('onewire')
         return
       case 'onewire-reset-panel':
         this.#oneWireAnchor = null
         this.#oneWireLastPoint = null
         this.#oneWireBusBarId = null
-        if (this.#tool !== 'onewire') this.#activateTool('onewire')
+        if (this.#tools.current !== 'onewire') this.#activateTool('onewire')
         else this.#render()
         return
       case 'onewire-realign':
@@ -4627,8 +4507,8 @@ export class CadleApp extends LiteElement {
         this.#panStart = {
           px: event.clientX - rect.left,
           py: event.clientY - rect.top,
-          panX: this.#panX,
-          panY: this.#panY
+          panX: this.#viewport.state.panX,
+          panY: this.#viewport.state.panY
         }
         this.#stagePointerId = event.pointerId
         ;(stage as SVGSVGElement).setPointerCapture(event.pointerId)
@@ -4639,7 +4519,7 @@ export class CadleApp extends LiteElement {
     const rawPoint = this.#pointFromEvent(event)
     if (!rawPoint) return
 
-    if (this.#tool === 'wall') {
+    if (this.#tools.current === 'wall') {
       // Wall chain must win before shape selection so existing walls can be used as click targets.
       const gridSnapped = this.#snapPoint(rawPoint)
       const { point, snapped } = this.#snapToEndpoints(gridSnapped)
@@ -4708,8 +4588,8 @@ export class CadleApp extends LiteElement {
     if (
       shapeId &&
       isAdditiveSelection &&
-      this.#tool !== 'onewire' &&
-      !(this.#tool === 'symbol' && this.#pendingCatalogSymbol)
+      this.#tools.current !== 'onewire' &&
+      !(this.#tools.current === 'symbol' && this.#pendingCatalogSymbol)
     ) {
       const expanded = this.#expandSelectionWithGroup(shapeId)
       const next = new Set(this.#selectedIds.size ? this.#selectedIds : this.#selectedId ? [this.#selectedId] : [])
@@ -4734,8 +4614,8 @@ export class CadleApp extends LiteElement {
     if (
       shapeId &&
       event.button === 0 &&
-      this.#tool !== 'onewire' &&
-      !(this.#tool === 'symbol' && this.#pendingCatalogSymbol)
+      this.#tools.current !== 'onewire' &&
+      !(this.#tools.current === 'symbol' && this.#pendingCatalogSymbol)
     ) {
       if (shapeId === PROJECT_LOGO_SHAPE_ID && isProjectLogoVisible(this.#project)) {
         this.#selectedIds = new Set([PROJECT_LOGO_SHAPE_ID])
@@ -4781,7 +4661,7 @@ export class CadleApp extends LiteElement {
       return
     }
 
-    if (this.#tool === 'text') {
+    if (this.#tools.current === 'text') {
       const value = window.prompt('Text', 'Label')?.trim()
       if (!value) return
       this.#shapes.push(createTextShape(nextShapeId(), rawPoint, value))
@@ -4791,7 +4671,7 @@ export class CadleApp extends LiteElement {
       return
     }
 
-    if (this.#tool === 'symbol' && event.button === 0 && this.#pendingCatalogSymbol) {
+    if (this.#tools.current === 'symbol' && event.button === 0 && this.#pendingCatalogSymbol) {
       const snapped = this.#snapSymbolPlacementPoint(rawPoint)
       this.#symbolPreviewPoint = snapped.point
       this.#snapTarget = snapped.snapped ? snapped.point : null
@@ -4806,7 +4686,7 @@ export class CadleApp extends LiteElement {
       return
     }
 
-    if (this.#tool === 'onewire') {
+    if (this.#tools.current === 'onewire') {
       if (event.button !== 0) return
 
       const clickedShape = shapeId ? this.#shapeById(shapeId) : null
@@ -4911,7 +4791,7 @@ export class CadleApp extends LiteElement {
       return
     }
 
-    if (this.#tool === 'select' || (this.#tool === 'symbol' && !this.#pendingCatalogSymbol)) {
+    if (this.#tools.current === 'select' || (this.#tools.current === 'symbol' && !this.#pendingCatalogSymbol)) {
       const selectResult = resolveSelectPointerDownState({
         shapeId,
         rawPoint,
@@ -4953,12 +4833,14 @@ export class CadleApp extends LiteElement {
     if (event.button !== 0) return
     const gridSnapped = this.#snapPoint(rawPoint)
     const point =
-      this.#tool === 'line'
+      this.#tools.current === 'line'
         ? this.#snapToElectricalPoints(gridSnapped).point
-        : this.#tool === 'door' || this.#tool === 'window' || this.#tool === 'gate'
+        : this.#tools.current === 'door' ||
+            this.#tools.current === 'window' ||
+            this.#tools.current === 'gate'
           ? this.#snapToEndpoints(gridSnapped).point
           : gridSnapped
-    this.#draft = createDraftShape(nextShapeId(), point, this.#tool)
+    this.#draft = createDraftShape(nextShapeId(), point, this.#tools.current)
     this.#stagePointerId = event.pointerId
     ;(stage as SVGSVGElement).setPointerCapture(event.pointerId)
     this.#render()
@@ -4973,8 +4855,7 @@ export class CadleApp extends LiteElement {
         const px = event.clientX - rect.left
         const py = event.clientY - rect.top
         const next = nextPanFromPointer(this.#panStart, px, py)
-        this.#panX = next.panX
-        this.#panY = next.panY
+        this.#viewport.setPan(next.panX, next.panY)
         this.#renderPreviewOnly()
       }
       return
@@ -5042,7 +4923,7 @@ export class CadleApp extends LiteElement {
       return
     }
 
-    if (this.#tool === 'symbol' && this.#pendingCatalogSymbol) {
+    if (this.#tools.current === 'symbol' && this.#pendingCatalogSymbol) {
       const snapped = this.#snapSymbolPlacementPoint(rawPoint)
       const nextPreview = snapped.point
       const nextSnapTarget = snapped.snapped ? snapped.point : null
@@ -5063,7 +4944,7 @@ export class CadleApp extends LiteElement {
     }
 
     // Wall chain: update live preview with snap
-    if (this.#tool === 'wall' && this.#wallChain) {
+    if (this.#tools.current === 'wall' && this.#wallChain) {
       const wallPreview = updateWallChainPreview(
         rawPoint,
         (point) => this.#snapPoint(point),
@@ -5077,7 +4958,7 @@ export class CadleApp extends LiteElement {
     }
 
     // One-wire: show snap preview
-    if (this.#tool === 'onewire') {
+    if (this.#tools.current === 'onewire') {
       if (this.#oneWireMode === 'compose' && this.#oneWireComposeKind === 'kamrail') {
         const snapped = this.#snapPoint(rawPoint)
         this.#snapTarget = snapped

--- a/src/native-app/document-history.ts
+++ b/src/native-app/document-history.ts
@@ -1,0 +1,45 @@
+import { cloneShapes } from '../native-draw/model.js'
+import type { Snapshot } from '../native-draw/types.js'
+
+const cloneSnapshot = (snapshot: Snapshot): Snapshot => ({
+  ...snapshot,
+  shapes: cloneShapes(snapshot.shapes)
+})
+
+/**
+ * Owns the editor's undo/redo timeline without knowing about rendering,
+ * persistence, or the custom element lifecycle.
+ */
+export class DocumentHistory {
+  #entries: Snapshot[] = []
+  #index = -1
+
+  reset(): void {
+    this.#entries = []
+    this.#index = -1
+  }
+
+  push(snapshot: Snapshot, replaceCurrent = false): void {
+    const next = cloneSnapshot(snapshot)
+    if (replaceCurrent && this.#index >= 0) {
+      this.#entries[this.#index] = next
+      return
+    }
+
+    this.#entries = this.#entries.slice(0, this.#index + 1)
+    this.#entries.push(next)
+    this.#index = this.#entries.length - 1
+  }
+
+  undo(): Snapshot | null {
+    if (this.#index <= 0) return null
+    this.#index -= 1
+    return cloneSnapshot(this.#entries[this.#index])
+  }
+
+  redo(): Snapshot | null {
+    if (this.#index >= this.#entries.length - 1) return null
+    this.#index += 1
+    return cloneSnapshot(this.#entries[this.#index])
+  }
+}

--- a/src/native-app/tool-controller.ts
+++ b/src/native-app/tool-controller.ts
@@ -1,0 +1,60 @@
+import type { Tool } from '../native-draw/types.js'
+
+const ACTION_TO_TOOL: Readonly<Record<string, Tool>> = {
+  'draw-wall': 'wall',
+  'draw-door': 'door',
+  'draw-window': 'window',
+  'draw-gate': 'gate',
+  'draw-line': 'line',
+  'draw-cable': 'line',
+  'draw-onewire': 'onewire',
+  'draw-square': 'rect',
+  'draw-circle': 'circle',
+  'draw-arc': 'arc',
+  'draw-text': 'text',
+  'draw-symbol': 'symbol',
+  draw: 'line',
+  resize: 'select',
+  select: 'select'
+}
+
+const TOOL_TO_ACTION: Readonly<Record<Tool, string>> = {
+  select: 'select',
+  wall: 'draw-wall',
+  door: 'draw-door',
+  window: 'draw-window',
+  gate: 'draw-gate',
+  line: 'draw-line',
+  onewire: 'draw-onewire',
+  rect: 'draw-square',
+  circle: 'draw-circle',
+  arc: 'draw-arc',
+  text: 'draw-text',
+  symbol: 'draw-symbol'
+}
+
+export class ToolController {
+  #current: Tool = 'select'
+
+  get current(): Tool {
+    return this.#current
+  }
+
+  select(tool: Tool): boolean {
+    if (tool === this.#current) return false
+    this.#current = tool
+    return true
+  }
+
+  selectForShellAction(action: string): boolean {
+    return this.select(ACTION_TO_TOOL[action] ?? 'select')
+  }
+
+  toolForShellAction(action: string): Tool {
+    return ACTION_TO_TOOL[action] ?? 'select'
+  }
+
+  shellAction(): string {
+    return TOOL_TO_ACTION[this.#current]
+  }
+}

--- a/src/native-app/viewport-controller.ts
+++ b/src/native-app/viewport-controller.ts
@@ -1,0 +1,65 @@
+import type { Point } from '../native-draw/types.js'
+
+export type ViewportState = Readonly<{
+  zoom: number
+  panX: number
+  panY: number
+}>
+
+export type Size = Readonly<{ width: number; height: number }>
+
+const MIN_ZOOM = 0.1
+const MAX_ZOOM = 8
+
+/** Keeps viewport transforms and zoom invariants out of the editor element. */
+export class ViewportController {
+  #zoom = 1
+  #panX = 0
+  #panY = 0
+
+  get state(): ViewportState {
+    return { zoom: this.#zoom, panX: this.#panX, panY: this.#panY }
+  }
+
+  screenToWorld(point: Point): Point {
+    return {
+      x: (point.x - this.#panX) / this.#zoom,
+      y: (point.y - this.#panY) / this.#zoom
+    }
+  }
+
+  zoomAt(point: Point, factor: number): boolean {
+    if (!Number.isFinite(factor) || factor <= 0) return false
+    const nextZoom = this.#clampZoom(this.#zoom * factor)
+    if (nextZoom === this.#zoom) return false
+
+    this.#panX = point.x - (point.x - this.#panX) * (nextZoom / this.#zoom)
+    this.#panY = point.y - (point.y - this.#panY) * (nextZoom / this.#zoom)
+    this.#zoom = nextZoom
+    return true
+  }
+
+  panBy(dx: number, dy: number): void {
+    if (Number.isFinite(dx)) this.#panX += dx
+    if (Number.isFinite(dy)) this.#panY += dy
+  }
+
+  setPan(panX: number, panY: number): void {
+    if (Number.isFinite(panX)) this.#panX = panX
+    if (Number.isFinite(panY)) this.#panY = panY
+  }
+
+  fit(container: Size, world: Size, margin = 12): boolean {
+    if (container.width <= 0 || container.height <= 0 || world.width <= 0 || world.height <= 0) return false
+    const availableWidth = Math.max(1, container.width - margin * 2)
+    const availableHeight = Math.max(1, container.height - margin * 2)
+    this.#zoom = this.#clampZoom(Math.min(1, availableWidth / world.width, availableHeight / world.height))
+    this.#panX = (container.width - world.width * this.#zoom) / 2
+    this.#panY = (container.height - world.height * this.#zoom) / 2
+    return true
+  }
+
+  #clampZoom(zoom: number): number {
+    return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom))
+  }
+}

--- a/src/native-draw/document-state.ts
+++ b/src/native-draw/document-state.ts
@@ -1,0 +1,46 @@
+import type { UUID } from '../types.js'
+import { sanitizeShapes } from './model.js'
+import type { PaperPreset, Shape } from './types.js'
+
+export type NativeDocumentState = {
+  version: 1
+  shapes: Shape[]
+  selectedId: UUID | null
+  paperPreset: PaperPreset
+  printMargin: number
+  worldWidth: number
+  worldHeight: number
+}
+
+const isFinitePositive = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0
+
+const isFiniteNonNegative = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0
+
+export const asNativeState = (value: unknown): NativeDocumentState | null => {
+  if (!value || typeof value !== 'object') return null
+  const candidate = value as Partial<NativeDocumentState>
+  if (!Array.isArray(candidate.shapes)) return null
+  if (!isFinitePositive(candidate.worldWidth)) return null
+  if (!isFinitePositive(candidate.worldHeight)) return null
+  if (!isFiniteNonNegative(candidate.printMargin)) return null
+  if (
+    candidate.paperPreset !== 'a4-portrait' &&
+    candidate.paperPreset !== 'a4-landscape' &&
+    candidate.paperPreset !== 'a3-portrait' &&
+    candidate.paperPreset !== 'a3-landscape'
+  ) {
+    return null
+  }
+
+  return {
+    version: 1,
+    shapes: sanitizeShapes(candidate.shapes),
+    selectedId: null,
+    paperPreset: candidate.paperPreset,
+    printMargin: candidate.printMargin,
+    worldWidth: candidate.worldWidth,
+    worldHeight: candidate.worldHeight
+  }
+}

--- a/src/native-draw/model.ts
+++ b/src/native-draw/model.ts
@@ -62,6 +62,7 @@ export const sanitizeShapes = (values: unknown[]): Shape[] => {
       bindingId?: unknown
       groupId?: unknown
       bindingLabelOffset?: unknown
+      catalogShapes?: unknown
     }
     if (typeof raw.id !== 'string' || !raw.id) continue
     if (typeof raw.kind !== 'string') continue

--- a/src/native-project-data.ts
+++ b/src/native-project-data.ts
@@ -6,18 +6,9 @@ import {
   type LegacyNativeDocumentState
 } from './native-draw/legacy-project.js'
 import { parseHash } from './shell/routing.js'
-import type { PaperPreset, Shape } from './native-draw/types.js'
-import { sanitizeShapes } from './native-draw/model.js'
+import { asNativeState, type NativeDocumentState } from './native-draw/document-state.js'
 
-export type NativeDocumentState = {
-  version: 1
-  shapes: Shape[]
-  selectedId: UUID | null
-  paperPreset: PaperPreset
-  printMargin: number
-  worldWidth: number
-  worldHeight: number
-}
+export { asNativeState, type NativeDocumentState } from './native-draw/document-state.js'
 
 type NativeSchemaObject = {
   kind: 'cadle-native-svg-document'
@@ -45,12 +36,6 @@ const createDefaultPage = (name = 'Page 1', order = 0) => ({
   order
 })
 
-const isFinitePositive = (value: unknown): value is number =>
-  typeof value === 'number' && Number.isFinite(value) && value > 0
-
-const isFiniteNonNegative = (value: unknown): value is number =>
-  typeof value === 'number' && Number.isFinite(value) && value >= 0
-
 const upgradeLegacyState = (state: LegacyNativeDocumentState | null): NativeDocumentState | null =>
   state
     ? {
@@ -58,33 +43,6 @@ const upgradeLegacyState = (state: LegacyNativeDocumentState | null): NativeDocu
         selectedId: null
       }
     : null
-
-export const asNativeState = (value: unknown): NativeDocumentState | null => {
-  if (!value || typeof value !== 'object') return null
-  const candidate = value as Partial<NativeDocumentState>
-  if (!Array.isArray(candidate.shapes)) return null
-  if (!isFinitePositive(candidate.worldWidth)) return null
-  if (!isFinitePositive(candidate.worldHeight)) return null
-  if (!isFiniteNonNegative(candidate.printMargin)) return null
-  if (
-    candidate.paperPreset !== 'a4-portrait' &&
-    candidate.paperPreset !== 'a4-landscape' &&
-    candidate.paperPreset !== 'a3-portrait' &&
-    candidate.paperPreset !== 'a3-landscape'
-  ) {
-    return null
-  }
-
-  return {
-    version: 1,
-    shapes: sanitizeShapes(candidate.shapes),
-    selectedId: null,
-    paperPreset: candidate.paperPreset,
-    printMargin: candidate.printMargin,
-    worldWidth: candidate.worldWidth,
-    worldHeight: candidate.worldHeight
-  }
-}
 
 const parseNativeFromSchema = (schema: unknown): NativeDocumentState | null => {
   const direct = asNativeState(schema)

--- a/src/shell/custom-symbols.ts
+++ b/src/shell/custom-symbols.ts
@@ -1,5 +1,7 @@
 import type { Catalog, JsonValue } from './../types.js'
 import { customCatalogStore } from '../api/catalog.js'
+import { sanitizeShapes } from '../native-draw/model.js'
+import type { Shape } from '../native-draw/types.js'
 /**
  * User-imported SVG symbols are persisted to @leofcoin/storage and merged
  * into the live catalog as catalog sections grouped by folder/category.
@@ -11,6 +13,7 @@ export type CustomCatalogSymbol = {
   kind?: string
   name: string
   path: string
+  shapes?: Shape[]
   metadata?: Record<string, JsonValue>
 }
 
@@ -49,12 +52,14 @@ const sanitizeSymbol = (input: unknown): CustomCatalogSymbol | null => {
     candidate.metadata && typeof candidate.metadata === 'object' && !Array.isArray(candidate.metadata)
       ? (candidate.metadata as Record<string, JsonValue>)
       : undefined
+  const shapes = Array.isArray(candidate.shapes) ? sanitizeShapes(candidate.shapes) : undefined
   return {
     folder: toFolderValue(candidate.folder),
     category,
     kind: kind || category,
     name,
     path,
+    shapes,
     metadata
   }
 }

--- a/test/circuit-analysis.test.ts
+++ b/test/circuit-analysis.test.ts
@@ -3,7 +3,6 @@ import test from 'node:test'
 import { analyzeCircuits, bomRowsToCsv, circuitBomRows } from '../src/native-app/circuit-analysis.ts'
 import type { Shape } from '../src/native-draw/types.ts'
 import { electricalMetadataFromCatalog } from '../src/native-draw/electrical.ts'
-import { asNativeState } from '../src/native-project-data.ts'
 
 const symbol = (id: string, bindingId: string, name: string, path: string): Shape => ({
   id,
@@ -13,20 +12,6 @@ const symbol = (id: string, bindingId: string, name: string, path: string): Shap
   bindingId,
   name,
   path
-})
-
-test('ignores persisted selection ids so restored documents start unselected', () => {
-  const state = asNativeState({
-    version: 1,
-    shapes: [],
-    selectedId: 'shape-1',
-    paperPreset: 'a4-landscape',
-    printMargin: 0,
-    worldWidth: 1000,
-    worldHeight: 1000
-  })
-
-  assert.equal(state?.selectedId, null)
 })
 
 test('groups floor-plan devices and ignores generated one-wire geometry', () => {

--- a/test/document-history.test.ts
+++ b/test/document-history.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { DocumentHistory } from '../src/native-app/document-history.ts'
+import type { Snapshot } from '../src/native-draw/types.ts'
+
+const snapshot = (id: string): Snapshot => ({
+  shapes: [
+    {
+      id,
+      kind: 'line',
+      start: { x: 0, y: 0 },
+      end: { x: 10, y: 10 }
+    }
+  ],
+  selectedId: id,
+  worldWidth: 100,
+  worldHeight: 100
+})
+
+test('walks backward and forward through document snapshots', () => {
+  const history = new DocumentHistory()
+  history.push(snapshot('first'))
+  history.push(snapshot('second'))
+
+  assert.equal(history.undo()?.selectedId, 'first')
+  assert.equal(history.undo(), null)
+  assert.equal(history.redo()?.selectedId, 'second')
+  assert.equal(history.redo(), null)
+})
+
+test('drops the redo branch after a new edit', () => {
+  const history = new DocumentHistory()
+  history.push(snapshot('first'))
+  history.push(snapshot('discarded'))
+  history.undo()
+  history.push(snapshot('replacement'))
+
+  assert.equal(history.redo(), null)
+  assert.equal(history.undo()?.selectedId, 'first')
+})
+
+test('clones snapshots at the controller boundary', () => {
+  const history = new DocumentHistory()
+  const input = snapshot('shape')
+  history.push(input)
+  input.shapes[0].id = 'mutated-input'
+
+  history.push(snapshot('later'))
+  const restored = history.undo()
+  assert.equal(restored?.shapes[0].id, 'shape')
+
+  if (restored) restored.shapes[0].id = 'mutated-output'
+  assert.equal(history.redo()?.selectedId, 'later')
+  assert.equal(history.undo()?.shapes[0].id, 'shape')
+})
+
+test('replaces the current entry without adding an undo step', () => {
+  const history = new DocumentHistory()
+  history.push(snapshot('first'))
+  history.push(snapshot('replacement'), true)
+
+  assert.equal(history.undo(), null)
+})

--- a/test/document-state.test.ts
+++ b/test/document-state.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { asNativeState } from '../src/native-draw/document-state.ts'
+
+test('ignores persisted selection ids so restored documents start unselected', () => {
+  const state = asNativeState({
+    version: 1,
+    shapes: [],
+    selectedId: 'shape-1',
+    paperPreset: 'a4-landscape',
+    printMargin: 0,
+    worldWidth: 1000,
+    worldHeight: 1000
+  })
+
+  assert.equal(state?.selectedId, null)
+})
+
+test('rejects malformed document dimensions and paper presets', () => {
+  const base = {
+    version: 1,
+    shapes: [],
+    selectedId: null,
+    paperPreset: 'a4-landscape',
+    printMargin: 0,
+    worldWidth: 1000,
+    worldHeight: 1000
+  }
+
+  assert.equal(asNativeState({ ...base, worldWidth: 0 }), null)
+  assert.equal(asNativeState({ ...base, printMargin: -1 }), null)
+  assert.equal(asNativeState({ ...base, paperPreset: 'letter' }), null)
+})

--- a/test/tool-controller.test.ts
+++ b/test/tool-controller.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ToolController } from '../src/native-app/tool-controller.ts'
+
+test('maps shell actions to editor tools', () => {
+  const tools = new ToolController()
+  assert.equal(tools.toolForShellAction('draw-wall'), 'wall')
+  assert.equal(tools.toolForShellAction('draw-cable'), 'line')
+  assert.equal(tools.toolForShellAction('unknown'), 'select')
+})
+
+test('maps the selected tool back to the canonical shell action', () => {
+  const tools = new ToolController()
+  tools.select('rect')
+  assert.equal(tools.shellAction(), 'draw-square')
+})
+
+test('reports whether selection actually changed', () => {
+  const tools = new ToolController()
+  assert.equal(tools.select('select'), false)
+  assert.equal(tools.selectForShellAction('draw-symbol'), true)
+  assert.equal(tools.current, 'symbol')
+  assert.equal(tools.selectForShellAction('draw-symbol'), false)
+})

--- a/test/viewport-controller.test.ts
+++ b/test/viewport-controller.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ViewportController } from '../src/native-app/viewport-controller.ts'
+
+test('converts screen coordinates to world coordinates', () => {
+  const viewport = new ViewportController()
+  viewport.setPan(20, 10)
+  viewport.zoomAt({ x: 20, y: 10 }, 2)
+
+  assert.deepEqual(viewport.screenToWorld({ x: 40, y: 30 }), { x: 10, y: 10 })
+})
+
+test('keeps the world point under the cursor fixed while zooming', () => {
+  const viewport = new ViewportController()
+  const anchor = { x: 120, y: 80 }
+  const before = viewport.screenToWorld(anchor)
+
+  viewport.zoomAt(anchor, 2)
+
+  assert.deepEqual(viewport.screenToWorld(anchor), before)
+})
+
+test('fits and centers a world inside a container', () => {
+  const viewport = new ViewportController()
+  assert.equal(viewport.fit({ width: 1000, height: 600 }, { width: 1600, height: 900 }), true)
+  assert.deepEqual(viewport.state, { zoom: 0.61, panX: 12, panY: 25.5 })
+})
+
+test('clamps zoom and rejects invalid factors', () => {
+  const viewport = new ViewportController()
+  viewport.zoomAt({ x: 0, y: 0 }, 100)
+  assert.equal(viewport.state.zoom, 8)
+  viewport.zoomAt({ x: 0, y: 0 }, 0.0001)
+  assert.equal(viewport.state.zoom, 0.1)
+  assert.equal(viewport.zoomAt({ x: 0, y: 0 }, Number.NaN), false)
+})


### PR DESCRIPTION
## Summary

- extract document history, viewport state, and tool selection into focused controllers
- move native document validation into a pure domain module
- preserve composite custom-symbol shapes during persistence sanitization
- add architecture and contribution guidance plus a single `npm run check` quality gate
- add focused tests for the new controller and document-state boundaries

## Why

`src/app.ts` had accumulated undo/redo, viewport math, tool mapping, rendering, persistence, and pointer behavior in one custom element. This made common editor changes harder to reason about and test. Some document validation also lived in a persistence module whose import initialized storage, preventing safe use from Node tests and tooling.

These extractions keep the public `<cadle-app>` API intact while giving maintainers smaller, framework-independent units with explicit invariants and tests.

## Developer impact

- editor state transitions can be tested without DOM or storage setup
- contributor documentation now explains module placement and dependency direction
- `npm run check` runs tests, TypeScript, and the production build
- custom composite symbols retain their source shapes after sanitization

## Validation

- `npm run check`
- 23 tests passing
- TypeScript check passing
- production Rollup build passing
- `git diff --check`
