### PR TITLE
Improve AREI-oriented one-wire workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 www/**/*.js
 www/**/*.mjs
 .DS_Store
+test-results/
+playwright-report/

--- a/package-lock.json
+++ b/package-lock.json
@@ -2292,9 +2292,9 @@
       "license": "MIT"
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2641,21 +2641,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -2883,6 +2868,21 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/typescript": {
       "name": "@typescript/typescript6",
       "version": "6.0.2",
@@ -2898,9 +2898,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "pdfjs-dist": "^6.1.200"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
@@ -30,6 +31,7 @@
         "rollup-plugin-css-modules": "^0.2.0",
         "rollup-plugin-material-symbols": "^2.1.7",
         "tslib": "^2.8.1",
+        "tsx": "^4.23.1",
         "typescript": "npm:@typescript/typescript6@^6.0.2"
       }
     },
@@ -71,6 +73,448 @@
       },
       "optionalDependencies": {
         "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -402,6 +846,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -1747,6 +2207,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -2107,6 +2609,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -2314,6 +2863,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "name": "@typescript/typescript6",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "generate:manifest": "node generate-manifest.js",
     "build": "npm run generate:manifest && rollup -c",
     "test": "node --import tsx --test test/**/*.test.ts",
+    "test:e2e": "npm run build && playwright test",
     "typecheck": "tsc --noEmit",
     "check": "npm test && npm run typecheck && npm run build"
   },
@@ -33,17 +34,19 @@
     "pdfjs-dist": "^6.1.200"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
+    "@typescript/native": "npm:typescript@^7.0.2",
     "@vandeurenglenn/lite": "^1.2.3",
     "electron": "^43.2.0",
     "rollup": "^4.62.2",
     "rollup-plugin-css-modules": "^0.2.0",
     "rollup-plugin-material-symbols": "^2.1.7",
     "tslib": "^2.8.1",
-    "@typescript/native": "npm:typescript@^7.0.2",
+    "tsx": "^4.23.1",
     "typescript": "npm:@typescript/typescript6@^6.0.2"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './test/e2e',
+  timeout: 45_000,
+  use: { baseURL: 'http://127.0.0.1:4333', channel: 'chrome', headless: true },
+  webServer: {
+    command: 'npm run standalone:serve',
+    url: 'http://127.0.0.1:4333',
+    reuseExistingServer: true
+  }
+})

--- a/src/app.ts
+++ b/src/app.ts
@@ -2379,7 +2379,7 @@ export class CadleApp extends LiteElement {
   }
 
   analyzeBindings(): CircuitAnalysis {
-    return analyzeCircuits(this.#groundplanShapePool())
+    return analyzeCircuits(this.#groundplanShapePool(), this.#project?.electricalProfile)
   }
 
   getBOMRows(): BomRow[] {

--- a/src/app.ts
+++ b/src/app.ts
@@ -99,19 +99,19 @@ import {
 } from './shell/custom-symbols.js'
 import { getCatalogSymbolStyleDefaults, setStoredCatalogSymbolStyleDefaults } from './shell/catalog-symbol-overrides.js'
 import {
-  analyzeCircuits,
   circuitBomRows,
   type CircuitAnalysis,
   type CircuitComponent,
   type BomRow
 } from './native-app/circuit-analysis.js'
-import { DocumentHistory } from './native-app/controllers/document-history.js'
 import { ViewportController } from './native-app/controllers/viewport-controller.js'
 import { ToolController } from './native-app/controllers/tool-controller.js'
+import { CanvasDocumentController } from './native-app/controllers/canvas-document-controller.js'
+import { OneWireController } from './native-app/controllers/onewire-controller.js'
+import { CatalogController } from './native-app/controllers/catalog-controller.js'
 import {
   symbolContentBounds
 } from './native-app/layout/symbol-layout.js'
-import { buildCatalogSelectionDraft } from './native-app/layout/catalog-selection.js'
 import {
   updateSelectionProperties,
   type SelectionPropertyUpdate
@@ -153,8 +153,9 @@ export class CadleApp extends LiteElement {
   static styles = [styles]
 
   #tools = new ToolController()
-  #shapes: Shape[] = []
-  #selectedId: string | null = null
+  #document = new CanvasDocumentController()
+  #oneWireController = new OneWireController()
+  #catalogController = new CatalogController()
   #draft: DraftShape | null = null
   #drag: DragState | null = null
   #logoDrag: { pointerStart: Point; initial: Point } | null = null
@@ -164,7 +165,6 @@ export class CadleApp extends LiteElement {
     shapeCenter: Point
     initialOffset: { x: number; y: number }
   } | null = null
-  #history = new DocumentHistory()
   #snap = true
   #stagePointerId: number | null = null
   #paperPreset: PaperPreset = 'a4-landscape'
@@ -198,7 +198,6 @@ export class CadleApp extends LiteElement {
   // Rubber-band select
   #bandStart: Point | null = null
   #bandEnd: Point | null = null
-  #selectedIds: Set<string> = new Set()
   #nativeClipboard: Shape[] = []
   #oneWireBindingId = 'A1'
   #oneWirePreset: OneWirePreset = 'sockets'
@@ -435,7 +434,7 @@ export class CadleApp extends LiteElement {
   }
 
   #openCatalogDialog = async (mode: CatalogDialogMode): Promise<boolean> => {
-    const draft = buildCatalogSelectionDraft(this.#shapes, this.#selectedShapeIds())
+    const draft = this.#catalogController.selectionDraft(this.#document.shapes, this.#selectedShapeIds())
     if (!draft) return false
 
     await ensureCustomCatalogLoaded()
@@ -574,8 +573,8 @@ export class CadleApp extends LiteElement {
 
   #onNativeObjectUpdate = (payload: SelectionPropertyUpdate) => {
     const hasLogoSelection =
-      this.#selectedIds.has(PROJECT_LOGO_SHAPE_ID) ||
-      (this.#selectedIds.size === 0 && this.#selectedId === PROJECT_LOGO_SHAPE_ID)
+      this.#document.selectedIds.has(PROJECT_LOGO_SHAPE_ID) ||
+      (this.#document.selectedIds.size === 0 && this.#document.selectedId === PROJECT_LOGO_SHAPE_ID)
     if (hasLogoSelection && this.#project && isProjectLogoVisible(this.#project)) {
       if (typeof payload.scale === 'number') {
         this.#project.logoScale = Math.max(0.4, Math.min(2.5, payload.scale))
@@ -608,26 +607,26 @@ export class CadleApp extends LiteElement {
       }
     }
 
-    const nextShapes = updateSelectionProperties(this.#shapes, payload, {
-      selectedIds: this.#selectedIds,
-      selectedId: this.#selectedId,
+    const nextShapes = updateSelectionProperties(this.#document.shapes, payload, {
+      selectedIds: this.#document.selectedIds,
+      selectedId: this.#document.selectedId,
       groupedSelection: this.#selectedGroupId() !== null
     })
     if (!nextShapes) return
-    this.#shapes = nextShapes
+    this.#document.shapes = nextShapes
     this.#pushHistory()
     this.#render()
   }
 
   #onNativeObjectDelete = () => {
-    if (this.#selectedId === PROJECT_LOGO_SHAPE_ID && this.#project) {
+    if (this.#document.selectedId === PROJECT_LOGO_SHAPE_ID && this.#project) {
       this.#project.logoUrl = undefined
       this.#project.logoColor = undefined
       this.#project.logoScale = 1
       this.#project.logoX = undefined
       this.#project.logoY = undefined
-      this.#selectedId = null
-      this.#selectedIds = new Set()
+      this.#document.selectedId = null
+      this.#document.selectedIds = new Set()
       cadleShell.project = this.#project
       void this.#persistProjectMetadata()
       this.#render()
@@ -635,21 +634,21 @@ export class CadleApp extends LiteElement {
     }
 
     const targets =
-      this.#selectedIds.size > 0
-        ? this.#selectedIds
-        : this.#selectedId
-          ? new Set([this.#selectedId])
+      this.#document.selectedIds.size > 0
+        ? this.#document.selectedIds
+        : this.#document.selectedId
+          ? new Set([this.#document.selectedId])
           : new Set<string>()
     if (!targets.size) return
-    this.#shapes = this.#shapes.filter((shape) => !targets.has(shape.id))
-    this.#selectedId = null
-    this.#selectedIds = new Set()
+    this.#document.shapes = this.#document.shapes.filter((shape) => !targets.has(shape.id))
+    this.#document.selectedId = null
+    this.#document.selectedIds = new Set()
     this.#pushHistory()
     this.#render()
   }
 
   #onNativeObjectFlipSide = () => {
-    const shape = this.#shapeById(this.#selectedId)
+    const shape = this.#shapeById(this.#document.selectedId)
     if (!shape || (shape.kind !== 'door' && shape.kind !== 'gate')) return
     const updated: LineShape = { ...shape, flipSide: !shape.flipSide }
     this.#setShape(updated)
@@ -658,11 +657,11 @@ export class CadleApp extends LiteElement {
   }
 
   async #initialize() {
-    this.#history.reset()
+    this.#document.history.reset()
     this.#draft = null
     this.#drag = null
-    this.#selectedId = null
-    this.#selectedIds = new Set()
+    this.#document.selectedId = null
+    this.#document.selectedIds = new Set()
 
     await this.#restore()
     this.#pushHistory(false)
@@ -767,7 +766,7 @@ export class CadleApp extends LiteElement {
 
   #applyPersistedState(parsed: Partial<NativeDocumentState>) {
     this.#resetPageState()
-    if (Array.isArray(parsed.shapes)) this.#shapes = sanitizeShapes(parsed.shapes)
+    if (Array.isArray(parsed.shapes)) this.#document.shapes = sanitizeShapes(parsed.shapes)
     this.#rebindAllOpeningsToWalls()
     if (typeof parsed.worldWidth === 'number' && Number.isFinite(parsed.worldWidth) && parsed.worldWidth > 0) {
       this.#worldWidth = parsed.worldWidth
@@ -784,9 +783,9 @@ export class CadleApp extends LiteElement {
   }
 
   #resetPageState() {
-    this.#shapes = []
-    this.#selectedId = null
-    this.#selectedIds = new Set()
+    this.#document.shapes = []
+    this.#document.selectedId = null
+    this.#document.selectedIds = new Set()
     this.#draft = null
     this.#drag = null
     this.#bandStart = null
@@ -807,10 +806,10 @@ export class CadleApp extends LiteElement {
   }
 
   #pushHistory(persist = true, replaceCurrent = false) {
-    this.#history.push(
+    this.#document.history.push(
       {
-        shapes: this.#shapes,
-        selectedId: this.#selectedId,
+        shapes: this.#document.shapes,
+        selectedId: this.#document.selectedId,
         worldWidth: this.#worldWidth,
         worldHeight: this.#worldHeight
       },
@@ -820,9 +819,9 @@ export class CadleApp extends LiteElement {
   }
 
   #restoreSnapshot(snapshot: Snapshot) {
-    this.#shapes = cloneShapes(snapshot.shapes)
+    this.#document.shapes = cloneShapes(snapshot.shapes)
     this.#rebindAllOpeningsToWalls()
-    this.#selectedId = snapshot.selectedId
+    this.#document.selectedId = snapshot.selectedId
     this.#worldWidth = snapshot.worldWidth
     this.#worldHeight = snapshot.worldHeight
     this.#draft = null
@@ -861,12 +860,12 @@ export class CadleApp extends LiteElement {
   }
 
   #undo() {
-    const snapshot = this.#history.undo()
+    const snapshot = this.#document.history.undo()
     if (snapshot) this.#restoreSnapshot(snapshot)
   }
 
   #redo() {
-    const snapshot = this.#history.redo()
+    const snapshot = this.#document.history.redo()
     if (snapshot) this.#restoreSnapshot(snapshot)
   }
 
@@ -992,7 +991,7 @@ export class CadleApp extends LiteElement {
     const minY = Math.min(a.y, b.y)
     const maxY = Math.max(a.y, b.y)
     const ids: string[] = []
-    for (const shape of this.#shapes) {
+    for (const shape of this.#document.shapes) {
       const bounds = shapeBounds(shape)
       if (bounds.x + bounds.width >= minX && bounds.x <= maxX && bounds.y + bounds.height >= minY && bounds.y <= maxY) {
         ids.push(shape.id)
@@ -1018,7 +1017,7 @@ export class CadleApp extends LiteElement {
 
   #shapeById(id: string | null): Shape | null {
     if (!id) return null
-    return this.#shapes.find((shape) => shape?.id === id) ?? null
+    return this.#document.shapes.find((shape) => shape?.id === id) ?? null
   }
 
   #pointNearSegment(point: Point, start: Point, end: Point, tolerance: number): boolean {
@@ -1065,7 +1064,7 @@ export class CadleApp extends LiteElement {
 
     let bestWall: LineShape | null = null
     let bestDistance = 8
-    for (const candidate of this.#shapes) {
+    for (const candidate of this.#document.shapes) {
       if (candidate.kind !== 'wall') continue
       const startDistance = this.#pointToSegmentDistance(shape.start, candidate.start, candidate.end)
       const endDistance = this.#pointToSegmentDistance(shape.end, candidate.start, candidate.end)
@@ -1085,8 +1084,8 @@ export class CadleApp extends LiteElement {
   }
 
   #rebindAllOpeningsToWalls() {
-    if (!this.#shapes.length) return
-    this.#shapes = this.#shapes.map((shape) => {
+    if (!this.#document.shapes.length) return
+    this.#document.shapes = this.#document.shapes.map((shape) => {
       if (!this.#isOpeningShape(shape)) return shape
       return this.#bindOpeningToWall(cloneShape(shape) as LineShape)
     })
@@ -1104,8 +1103,8 @@ export class CadleApp extends LiteElement {
       return PROJECT_LOGO_SHAPE_ID
     }
     const tolerance = Math.max(6, 12 / this.#viewport.state.zoom)
-    for (let index = this.#shapes.length - 1; index >= 0; index -= 1) {
-      const shape = this.#shapes[index]
+    for (let index = this.#document.shapes.length - 1; index >= 0; index -= 1) {
+      const shape = this.#document.shapes[index]
       if (
         shape.kind === 'wall' ||
         shape.kind === 'line' ||
@@ -1155,8 +1154,8 @@ export class CadleApp extends LiteElement {
   }
 
   #selectedShapeIds(): string[] {
-    if (this.#selectedIds.size > 0) return [...this.#selectedIds]
-    return this.#selectedId ? [this.#selectedId] : []
+    if (this.#document.selectedIds.size > 0) return [...this.#document.selectedIds]
+    return this.#document.selectedId ? [this.#document.selectedId] : []
   }
 
   #expandSelectionWithGroup(shapeId: string): Set<string> {
@@ -1166,7 +1165,7 @@ export class CadleApp extends LiteElement {
     // One-wire groupIds are layout metadata (realign, label dedupe) — shapes
     // stay individually selectable. Only user-made groups select as a whole.
     if (groupId.startsWith('onewire-')) return new Set([shapeId])
-    return new Set(this.#shapes.filter((item) => item.groupId === groupId).map((item) => item.id))
+    return new Set(this.#document.shapes.filter((item) => item.groupId === groupId).map((item) => item.id))
   }
 
   #selectedGroupIds(): string[] {
@@ -1239,17 +1238,17 @@ export class CadleApp extends LiteElement {
       })
 
       // Add unpacked shapes to canvas
-      this.#shapes.push(...unpacked)
+      this.#document.shapes.push(...unpacked)
 
       // Remove the symbol
-      this.#shapes = this.#shapes.filter((s) => s.id !== id)
+      this.#document.shapes = this.#document.shapes.filter((s) => s.id !== id)
       unpackedAny = true
     }
 
     if (unpackedAny) {
       // Select the unpacked shapes as a group
-      this.#selectedIds = new Set(unpackedIds)
-      this.#selectedId = unpackedIds[0] ?? null
+      this.#document.selectedIds = new Set(unpackedIds)
+      this.#document.selectedId = unpackedIds[0] ?? null
       this.#pushHistory()
       this.#render()
       return true
@@ -1262,7 +1261,7 @@ export class CadleApp extends LiteElement {
     const targetGroups = new Set(groupIds)
     let ungroupedAny = false
 
-    for (const shape of this.#shapes) {
+    for (const shape of this.#document.shapes) {
       if (!shape.groupId || !targetGroups.has(shape.groupId)) continue
       const updated = { ...shape }
       delete updated.groupId
@@ -1491,8 +1490,8 @@ export class CadleApp extends LiteElement {
     const shapeId = shapeElement?.dataset.shapeId ?? null
 
     if (shapeId) {
-      if (!this.#selectedIds.has(shapeId)) this.#selectedIds = this.#expandSelectionWithGroup(shapeId)
-      this.#selectedId = shapeId
+      if (!this.#document.selectedIds.has(shapeId)) this.#document.selectedIds = this.#expandSelectionWithGroup(shapeId)
+      this.#document.selectedId = shapeId
     }
 
     this.#stageContextPastePoint = this.#pointFromEvent(event as PointerEvent)
@@ -1508,8 +1507,8 @@ export class CadleApp extends LiteElement {
     let shapeId = shapeElement?.dataset.shapeId ?? null
     shapeId ??= this.#shapeIdAtPoint(point)
     if (!shapeId) {
-      this.#selectedIds = new Set(this.#shapes.map((shape) => shape.id))
-      this.#selectedId = this.#shapes[0]?.id ?? null
+      this.#document.selectedIds = new Set(this.#document.shapes.map((shape) => shape.id))
+      this.#document.selectedId = this.#document.shapes[0]?.id ?? null
       this.#drag = null
       this.#bandStart = null
       this.#bandEnd = null
@@ -1525,15 +1524,15 @@ export class CadleApp extends LiteElement {
     if (shape.kind === 'text') {
       const nextText = window.prompt('Text', shape.text)?.trim()
       if (!nextText || nextText === shape.text) {
-        this.#selectedId = shape.id
-        this.#selectedIds = new Set([shape.id])
+        this.#document.selectedId = shape.id
+        this.#document.selectedIds = new Set([shape.id])
         this.#render()
         return
       }
 
       this.#setShape({ ...shape, text: nextText } as TextShape)
-      this.#selectedId = shape.id
-      this.#selectedIds = new Set([shape.id])
+      this.#document.selectedId = shape.id
+      this.#document.selectedIds = new Set([shape.id])
       this.#pushHistory()
       this.#render()
       return
@@ -1542,8 +1541,8 @@ export class CadleApp extends LiteElement {
     if (!shape.groupId) return
 
     // In a group: double-click isolates one shape for direct edit/delete operations.
-    this.#selectedIds = new Set([shapeId])
-    this.#selectedId = shapeId
+    this.#document.selectedIds = new Set([shapeId])
+    this.#document.selectedId = shapeId
     this.#drag = null
     this.#bandStart = null
     this.#bandEnd = null
@@ -1680,9 +1679,9 @@ export class CadleApp extends LiteElement {
       }
       return next
     })
-    this.#shapes.push(...pasted)
-    this.#selectedIds = new Set(pasted.map((shape) => shape.id))
-    this.#selectedId = pasted[0]?.id ?? null
+    this.#document.shapes.push(...pasted)
+    this.#document.selectedIds = new Set(pasted.map((shape) => shape.id))
+    this.#document.selectedId = pasted[0]?.id ?? null
     this.#pushHistory()
     this.#render()
     return true
@@ -1691,9 +1690,9 @@ export class CadleApp extends LiteElement {
   #deleteNativeSelection(): boolean {
     const ids = new Set(this.#selectedShapeIds())
     if (!ids.size) return false
-    this.#shapes = this.#shapes.filter((shape) => !ids.has(shape.id))
-    this.#selectedId = null
-    this.#selectedIds = new Set()
+    this.#document.shapes = this.#document.shapes.filter((shape) => !ids.has(shape.id))
+    this.#document.selectedId = null
+    this.#document.selectedIds = new Set()
     this.#pushHistory()
     this.#render()
     return true
@@ -1719,24 +1718,24 @@ export class CadleApp extends LiteElement {
     if (!selected.size) return false
 
     if (action === 'bring-to-front') {
-      const rest = this.#shapes.filter((shape) => !selected.has(shape.id))
-      const picked = this.#shapes.filter((shape) => selected.has(shape.id))
-      this.#shapes = [...rest, ...picked]
+      const rest = this.#document.shapes.filter((shape) => !selected.has(shape.id))
+      const picked = this.#document.shapes.filter((shape) => selected.has(shape.id))
+      this.#document.shapes = [...rest, ...picked]
       this.#pushHistory()
       this.#render()
       return true
     }
 
     if (action === 'send-to-back') {
-      const picked = this.#shapes.filter((shape) => selected.has(shape.id))
-      const rest = this.#shapes.filter((shape) => !selected.has(shape.id))
-      this.#shapes = [...picked, ...rest]
+      const picked = this.#document.shapes.filter((shape) => selected.has(shape.id))
+      const rest = this.#document.shapes.filter((shape) => !selected.has(shape.id))
+      this.#document.shapes = [...picked, ...rest]
       this.#pushHistory()
       this.#render()
       return true
     }
 
-    const next = [...this.#shapes]
+    const next = [...this.#document.shapes]
     let changed = false
     if (action === 'bring-forward') {
       for (let index = next.length - 2; index >= 0; index -= 1) {
@@ -1753,7 +1752,7 @@ export class CadleApp extends LiteElement {
     }
 
     if (!changed) return false
-    this.#shapes = next
+    this.#document.shapes = next
     this.#pushHistory()
     this.#render()
     return true
@@ -1782,8 +1781,8 @@ export class CadleApp extends LiteElement {
       case 'scale-down':
         return this.#transformNativeSelection('scale-down')
       case 'select-all':
-        this.#selectedIds = new Set(this.#shapes.map((shape) => shape.id))
-        this.#selectedId = this.#shapes[0]?.id ?? null
+        this.#document.selectedIds = new Set(this.#document.shapes.map((shape) => shape.id))
+        this.#document.selectedId = this.#document.shapes[0]?.id ?? null
         this.#render()
         return true
       case 'delete':
@@ -1880,8 +1879,8 @@ export class CadleApp extends LiteElement {
       hasWallChain: Boolean(this.#wallChain),
       hasDraft: Boolean(this.#draft),
       hasDrag: Boolean(this.#drag),
-      selectedId: this.#selectedId,
-      selectedCount: this.#selectedIds.size,
+      selectedId: this.#document.selectedId,
+      selectedCount: this.#document.selectedIds.size,
       hasBandStart: Boolean(this.#bandStart),
       hasOneWireAnchor: Boolean(this.#oneWireAnchor)
     })
@@ -1915,8 +1914,8 @@ export class CadleApp extends LiteElement {
     if (action === 'clear-interaction') {
       this.#draft = null
       this.#drag = null
-      this.#selectedId = null
-      this.#selectedIds = new Set()
+      this.#document.selectedId = null
+      this.#document.selectedIds = new Set()
       this.#bandStart = null
       this.#bandEnd = null
       this.#snapTarget = null
@@ -1939,7 +1938,7 @@ export class CadleApp extends LiteElement {
     const SNAP_RADIUS = 20
     let best: Point | null = null
     let bestDist = SNAP_RADIUS
-    for (const shape of this.#shapes) {
+    for (const shape of this.#document.shapes) {
       if (!this.#isEndpointSnapShape(shape)) continue
       for (const ep of [shape.start, shape.end]) {
         const dist = Math.hypot(ep.x - point.x, ep.y - point.y)
@@ -2003,7 +2002,7 @@ export class CadleApp extends LiteElement {
     let hostSymbol: SymbolShape | null = null
     let side: 'top' | 'bottom' | 'left' | 'right' | null = null
 
-    for (const shape of this.#shapes) {
+    for (const shape of this.#document.shapes) {
       if (shape.kind === 'line' && shape.bindingId) {
         for (const ep of [shape.start, shape.end]) {
           const dist = Math.hypot(ep.x - point.x, ep.y - point.y)
@@ -2057,7 +2056,7 @@ export class CadleApp extends LiteElement {
     let bestPoint: Point | null = null
     let bestDistance = snapRadius
 
-    for (const shape of this.#shapes) {
+    for (const shape of this.#document.shapes) {
       if (shape.kind !== 'wall') continue
       const closest = this.#closestPointOnSegment(point, shape.start, shape.end)
       const distance = Math.hypot(point.x - closest.x, point.y - closest.y)
@@ -2094,7 +2093,7 @@ export class CadleApp extends LiteElement {
     let best: Point | null = null
     let bestDistance = SNAP_RADIUS
 
-    for (const shape of this.#shapes) {
+    for (const shape of this.#document.shapes) {
       if (shape.kind !== 'line') continue
       const closest = this.#closestPointOnSegment(point, shape.start, shape.end)
       const distance = Math.hypot(point.x - closest.x, point.y - closest.y)
@@ -2176,10 +2175,10 @@ export class CadleApp extends LiteElement {
   // the visible edges of the symbols sitting on it. Wires never cross symbols.
   #realignExistingOneWire(): boolean {
     const isOneWire = (shape: Shape) => typeof shape.groupId === 'string' && shape.groupId.startsWith('onewire-')
-    const groupedOneWireShapes = this.#shapes.filter(
+    const groupedOneWireShapes = this.#document.shapes.filter(
       (shape) => isOneWire(shape) && !shape.groupId!.startsWith('onewire-kamrail-')
     )
-    const bindingFallbackShapes = this.#shapes.filter((shape) => {
+    const bindingFallbackShapes = this.#document.shapes.filter((shape) => {
       if (shape.kind !== 'line' && shape.kind !== 'symbol') return false
       if (typeof shape.groupId === 'string' && shape.groupId.startsWith('onewire-kamrail-')) return false
       return typeof shape.bindingId === 'string' && shape.bindingId.trim().length > 0
@@ -2331,12 +2330,12 @@ export class CadleApp extends LiteElement {
 
     if (!updatedShapes.size && !removedIds.size) return false
 
-    this.#shapes = this.#shapes
+    this.#document.shapes = this.#document.shapes
       .filter((shape) => !removedIds.has(shape.id))
       .map((shape) => updatedShapes.get(shape.id) ?? shape)
-    this.#shapes.push(...addedShapes)
-    this.#selectedId = null
-    this.#selectedIds = new Set()
+    this.#document.shapes.push(...addedShapes)
+    this.#document.selectedId = null
+    this.#document.selectedIds = new Set()
     this.#pushHistory()
     this.#render()
     return true
@@ -2363,7 +2362,7 @@ export class CadleApp extends LiteElement {
 
   #groundplanShapePool(): Shape[] {
     const currentPageType = this.#pageKey ? this.#project?.pages?.[this.#pageKey]?.pageType : undefined
-    const pool: Shape[] = currentPageType === 'onewire' ? [] : [...this.#shapes]
+    const pool: Shape[] = currentPageType === 'onewire' ? [] : [...this.#document.shapes]
     if (!this.#project?.pages) return pool
 
     for (const pageKey of Object.keys(this.#project.pages) as UUID[]) {
@@ -2379,14 +2378,14 @@ export class CadleApp extends LiteElement {
   }
 
   analyzeBindings(): CircuitAnalysis {
-    return analyzeCircuits(this.#groundplanShapePool(), this.#project?.electricalProfile)
+    return this.#oneWireController.analyze(this.#groundplanShapePool(), this.#project?.electricalProfile)
   }
 
   getBOMRows(): BomRow[] {
     return circuitBomRows(this.analyzeBindings())
   }
 
-  generateAutoOneWire(): { generated: boolean; circuitCount: number; message?: string } {
+  generateAutoOneWire(pageIndex = 0): { generated: boolean; circuitCount: number; pageCount?: number; message?: string } {
     const currentPageType = this.#pageKey ? this.#project?.pages?.[this.#pageKey]?.pageType : undefined
     if (currentPageType !== 'onewire') {
       return { generated: false, circuitCount: 0, message: 'Open a one-wire page before generating.' }
@@ -2402,22 +2401,43 @@ export class CadleApp extends LiteElement {
       }
     }
 
-    this.#shapes = this.#shapes.filter((shape) => !shape.groupId?.startsWith('onewire-'))
-    const railY = Math.max(220, this.#worldHeight - 180)
-    const rail: LineShape = {
-      id: nextShapeId(),
-      kind: 'line',
-      start: { x: 80, y: railY },
-      end: { x: Math.max(500, this.#worldWidth - 80), y: railY },
-      stroke: '#111111',
-      strokeWidth: KAMRAIL_STROKE_WIDTH,
-      groupId: `onewire-kamrail-${nextShapeId()}`
+    const previousGenerated = this.#document.shapes.filter((shape) => shape.groupId?.startsWith('onewire-'))
+    const retainedShapes = this.#document.shapes.filter((shape) => !shape.groupId?.startsWith('onewire-'))
+    this.#document.shapes = [...retainedShapes]
+    const railStartX = 80
+    const railEndX = Math.max(500, this.#worldWidth - 80)
+    const usableWidth = Math.max(1, railEndX - railStartX)
+    const layoutPlan = this.#oneWireController.plan(
+      analysis.families.map((family) => ({
+        family,
+        circuitCount: analysis.groups.filter((group) => group.family === family).length
+      })),
+      usableWidth,
+      Math.max(320, this.#worldHeight - 160)
+    )
+    const visiblePlacements = layoutPlan.placements.filter((placement) => placement.pageIndex === pageIndex)
+    if (!visiblePlacements.length) {
+      return { generated: false, circuitCount: analysis.totalGroups, pageCount: layoutPlan.pageCount, message: 'No circuits are assigned to this one-wire page.' }
     }
-    this.#shapes.push(rail)
+    const rails = new Map<number, LineShape>()
+    for (const railIndex of new Set(visiblePlacements.map((placement) => placement.railIndex))) {
+      const railY = Math.max(220, this.#worldHeight - 180 - railIndex * 320)
+      const rail: LineShape = {
+        id: nextShapeId(), kind: 'line', start: { x: railStartX, y: railY }, end: { x: railEndX, y: railY },
+        stroke: '#111111', strokeWidth: KAMRAIL_STROKE_WIDTH,
+        groupId: `onewire-kamrail-${nextShapeId()}`,
+        generationKey: `board:main:rail:${railIndex}`,
+        sourceLink: { kind: 'board', id: 'main', role: `rail-${railIndex + 1}` }
+      }
+      rails.set(railIndex, rail)
+      this.#document.shapes.push(rail)
+    }
 
-    const usableWidth = Math.max(1, rail.end.x - rail.start.x)
-    analysis.families.forEach((family, index) => {
-      const x = rail.start.x + (usableWidth * (index + 1)) / (analysis.families.length + 1)
+    visiblePlacements.forEach((placement) => {
+      const family = placement.family
+      const rail = rails.get(placement.railIndex)
+      if (!rail) return
+      const x = rail.start.x + (usableWidth * (placement.slotIndex + 0.5)) / layoutPlan.slotsPerRail
       const familyCurrent = Math.max(
         ...analysis.groups
           .filter((group) => group.family === family)
@@ -2426,14 +2446,22 @@ export class CadleApp extends LiteElement {
       this.#addKamrailCircuitBundle(rail, x, { amps: familyCurrent, family, autoIncludeFamily: true })
     })
 
+    const freshGenerated = this.#document.shapes.slice(retainedShapes.length)
+    const reconciled = this.#oneWireController.reconcile(previousGenerated, freshGenerated)
+    this.#document.shapes = [...retainedShapes, ...reconciled.shapes]
+
     this.#pushHistory()
     this.#render()
-    return { generated: true, circuitCount: analysis.totalGroups }
+    return {
+      generated: true,
+      circuitCount: analysis.totalGroups,
+      pageCount: layoutPlan.pageCount
+    }
   }
 
   #groundplanComponentsForFamily(
     family: string
-  ): Array<{ bindingId: string; kind: 'switch' | 'load'; sourcePath?: string; sourceName?: string }> {
+  ): Array<{ bindingId: string; kind: 'switch' | 'load'; sourceShapeId: string; sourcePath?: string; sourceName?: string }> {
     return this.analyzeBindings()
       .groups.filter((group) => group.family === family)
       .flatMap((group) =>
@@ -2445,6 +2473,7 @@ export class CadleApp extends LiteElement {
           .map((component) => ({
             bindingId: group.bindingId,
             kind: component.role,
+            sourceShapeId: component.shapeId,
             sourcePath: component.path,
             sourceName: component.name
           }))
@@ -2471,9 +2500,9 @@ export class CadleApp extends LiteElement {
     })
 
     if (!result) return false
-    this.#shapes.push(...result.shapes)
-    this.#selectedId = result.selectedId
-    this.#selectedIds = new Set(result.createdIds)
+    this.#document.shapes.push(...result.shapes)
+    this.#document.selectedId = result.selectedId
+    this.#document.selectedIds = new Set(result.createdIds)
     this.#oneWireBindingId = this.#nextOneWireBindingId()
     return true
   }
@@ -2483,7 +2512,7 @@ export class CadleApp extends LiteElement {
     let best: { rail: LineShape; point: Point } | null = null
     let bestDistance = SNAP_RADIUS
 
-    for (const shape of this.#shapes) {
+    for (const shape of this.#document.shapes) {
       if (shape.kind !== 'line') continue
       if (!shape.groupId?.startsWith('onewire-kamrail-')) continue
       const closest = this.#closestPointOnSegment(point, shape.start, shape.end)
@@ -2512,9 +2541,9 @@ export class CadleApp extends LiteElement {
       groupId
     }
 
-    this.#shapes.push(rail)
-    this.#selectedId = rail.id
-    this.#selectedIds = new Set([rail.id])
+    this.#document.shapes.push(rail)
+    this.#document.selectedId = rail.id
+    this.#document.selectedIds = new Set([rail.id])
     return true
   }
 
@@ -2575,9 +2604,9 @@ export class CadleApp extends LiteElement {
       groupId
     }
 
-    this.#shapes.push(connector, symbol, label)
-    this.#selectedId = symbol.id
-    this.#selectedIds = new Set([connector.id, symbol.id, label.id])
+    this.#document.shapes.push(connector, symbol, label)
+    this.#document.selectedId = symbol.id
+    this.#document.selectedIds = new Set([connector.id, symbol.id, label.id])
     this.#oneWireBindingId = this.#nextOneWireBindingId()
     return true
   }
@@ -2660,9 +2689,9 @@ export class CadleApp extends LiteElement {
       groupId
     }
 
-    this.#shapes.push(connector, newSymbol)
-    this.#selectedId = newSymbol.id
-    this.#selectedIds = new Set([connector.id, newSymbol.id])
+    this.#document.shapes.push(connector, newSymbol)
+    this.#document.selectedId = newSymbol.id
+    this.#document.selectedIds = new Set([connector.id, newSymbol.id])
     return true
   }
 
@@ -2675,7 +2704,7 @@ export class CadleApp extends LiteElement {
     let snapType: 'none' | 'x' | 'y' | 'both' = 'none'
 
     // Snap to existing one-wire circuit X positions (columns) and bus bar Y
-    for (const shape of this.#shapes) {
+    for (const shape of this.#document.shapes) {
       if (shape.kind === 'symbol' && shape.bindingId) {
         for (const cp of this.#symbolConnectionPoints(shape)) {
           const xDist = Math.abs(cp.x - point.x)
@@ -2710,15 +2739,15 @@ export class CadleApp extends LiteElement {
   }
 
   #setShape(shape: Shape) {
-    const index = this.#shapes.findIndex((item) => item?.id === shape.id)
+    const index = this.#document.shapes.findIndex((item) => item?.id === shape.id)
     if (index < 0) return
-    this.#shapes[index] = shape
+    this.#document.shapes[index] = shape
   }
 
   #setShapes(shapes: Shape[]) {
     if (!shapes.length) return
     const updates = new Map(shapes.map((shape) => [shape.id, shape]))
-    this.#shapes = this.#shapes.map((shape) => updates.get(shape.id) ?? shape)
+    this.#document.shapes = this.#document.shapes.map((shape) => updates.get(shape.id) ?? shape)
   }
 
   #shapeTemplate(shape: Shape, selected: boolean, extraClass = '') {
@@ -2726,7 +2755,7 @@ export class CadleApp extends LiteElement {
   }
 
   #bindingLabelsTemplate() {
-    return bindingLabelsTemplate(this.#shapes)
+    return bindingLabelsTemplate(this.#document.shapes)
   }
 
   #selectedOutlineTemplate(shape: Shape | null) {
@@ -2750,7 +2779,7 @@ export class CadleApp extends LiteElement {
   }
 
   #publishNativeSelection(selectedShape: Shape | null) {
-    if (this.#selectedId === PROJECT_LOGO_SHAPE_ID && isProjectLogoVisible(this.#project)) {
+    if (this.#document.selectedId === PROJECT_LOGO_SHAPE_ID && isProjectLogoVisible(this.#project)) {
       const logoBounds = getProjectLogoBounds(this.#project)
       const logoScaleRaw =
         typeof this.#project?.logoScale === 'number' && Number.isFinite(this.#project.logoScale)
@@ -2777,7 +2806,7 @@ export class CadleApp extends LiteElement {
     const groupedSelection = this.#selectedGroupId()
     pubsub.publish(
       'native.selection.changed',
-      createNativeSelectionChangedPayload(selectedShape, groupedSelection ? 1 : this.#selectedIds.size, {
+      createNativeSelectionChangedPayload(selectedShape, groupedSelection ? 1 : this.#document.selectedIds.size, {
         kindOverride: groupedSelection ? 'group' : undefined,
         bindingIdOverride: groupedSelection ? this.#selectedGroupBindingId() : undefined
       })
@@ -2787,7 +2816,7 @@ export class CadleApp extends LiteElement {
   #nativeDocumentState(): NativeDocumentState {
     return {
       version: 1,
-      shapes: this.#shapes,
+      shapes: this.#document.shapes,
       selectedId: null,
       paperPreset: this.#paperPreset,
       printMargin: this.#printMargin,
@@ -2811,14 +2840,14 @@ export class CadleApp extends LiteElement {
   #exportViewBox(
     orientation: 'portrait' | 'landscape'
   ): { x: number; y: number; width: number; height: number } | null {
-    if (!this.#shapes.length) return null
+    if (!this.#document.shapes.length) return null
 
     let minX = Number.POSITIVE_INFINITY
     let minY = Number.POSITIVE_INFINITY
     let maxX = Number.NEGATIVE_INFINITY
     let maxY = Number.NEGATIVE_INFINITY
 
-    for (const shape of this.#shapes) {
+    for (const shape of this.#document.shapes) {
       const bounds = shapeBounds(shape)
       minX = Math.min(minX, bounds.x)
       minY = Math.min(minY, bounds.y)
@@ -2882,8 +2911,8 @@ export class CadleApp extends LiteElement {
     const buildDocument = buildSvgDocument as unknown as (options: Record<string, unknown>) => string
     const overlayScale = viewBox ? Math.min(viewBox.width / this.#worldWidth, viewBox.height / this.#worldHeight) : 1
     const exportOptions: Record<string, unknown> = {
-      shapes: this.#shapes,
-      selectedShape: this.#shapeById(this.#selectedId),
+      shapes: this.#document.shapes,
+      selectedShape: this.#shapeById(this.#document.selectedId),
       paper: this.#paperMeta(),
       worldWidth: this.#worldWidth,
       worldHeight: this.#worldHeight,
@@ -2935,7 +2964,7 @@ export class CadleApp extends LiteElement {
 
   async #ensureSymbolMarkupReady() {
     const symbolPaths = new Set<string>()
-    for (const shape of this.#shapes) {
+    for (const shape of this.#document.shapes) {
       if (shape.kind === 'symbol') symbolPaths.add(shape.path)
     }
     if (this.#pendingCatalogSymbol?.path) symbolPaths.add(this.#pendingCatalogSymbol.path)
@@ -2954,7 +2983,7 @@ export class CadleApp extends LiteElement {
 
   #primeSymbolSvgCache() {
     const symbolPaths = new Set<string>()
-    for (const shape of this.#shapes) {
+    for (const shape of this.#document.shapes) {
       if (shape.kind === 'symbol') symbolPaths.add(shape.path)
     }
     if (this.#pendingCatalogSymbol?.path) symbolPaths.add(this.#pendingCatalogSymbol.path)
@@ -3003,7 +3032,7 @@ export class CadleApp extends LiteElement {
     await this.#ensureSymbolMarkupReady()
     const originalPageKey = this.#pageKey
     const originalState = this.#nativeDocumentState()
-    const originalSelectedIds = new Set(this.#selectedIds)
+    const originalSelectedIds = new Set(this.#document.selectedIds)
     const originalDraft = this.#draft ? (cloneShape(this.#draft) as DraftShape) : null
     const originalDrag = this.#drag ? { ...this.#drag, initial: cloneShapes(this.#drag.initial) } : null
     const originalBandStart = this.#bandStart ? { ...this.#bandStart } : null
@@ -3050,8 +3079,8 @@ export class CadleApp extends LiteElement {
         if (!state) continue
 
         this.#applyPersistedState(state)
-        this.#selectedId = null
-        this.#selectedIds = new Set()
+        this.#document.selectedId = null
+        this.#document.selectedIds = new Set()
         this.#pageKey = pageKey as UUID
 
         const exportViewBox = this.#exportViewBox(this.#worldWidth >= this.#worldHeight ? 'landscape' : 'portrait')
@@ -3099,8 +3128,8 @@ export class CadleApp extends LiteElement {
     } finally {
       this.#applyPersistedState(originalState)
       this.#pageKey = originalPageKey
-      this.#selectedId = originalState.selectedId ?? null
-      this.#selectedIds = originalSelectedIds
+      this.#document.selectedId = originalState.selectedId ?? null
+      this.#document.selectedIds = originalSelectedIds
       this.#draft = originalDraft
       this.#drag = originalDrag
       this.#bandStart = originalBandStart
@@ -3169,7 +3198,7 @@ export class CadleApp extends LiteElement {
 
         if (Array.isArray(nativeShapes)) this.#applyPersistedState({ shapes: nativeShapes })
         else return
-        this.#selectedId = null
+        this.#document.selectedId = null
         this.#draft = null
         this.#drag = null
         this.#pushHistory()
@@ -3182,7 +3211,7 @@ export class CadleApp extends LiteElement {
   }
 
   render() {
-    const selectedShape = this.#shapeById(this.#selectedId)
+    const selectedShape = this.#shapeById(this.#document.selectedId)
     const { zoom, panX, panY } = this.#viewport.state
     const worldTransform = `translate(${panX} ${panY}) scale(${zoom})`
     const minorGrid = GRID_SIZE * 2 * zoom
@@ -3455,20 +3484,20 @@ export class CadleApp extends LiteElement {
   }
 
   #hasWallOpenings(): boolean {
-    return this.#shapes.some((shape) => shape.kind === 'door' || shape.kind === 'window' || shape.kind === 'gate')
+    return this.#document.shapes.some((shape) => shape.kind === 'door' || shape.kind === 'window' || shape.kind === 'gate')
   }
 
   #wallMaskTemplate() {
-    return wallMaskTemplate(this.#shapes, this.#worldWidth, this.#worldHeight)
+    return wallMaskTemplate(this.#document.shapes, this.#worldWidth, this.#worldHeight)
   }
 
   #committedTemplate(selectedShape: Shape | null) {
-    const wallShapes = this.#shapes.filter((shape) => shape.kind === 'wall')
-    const openingShapes = this.#shapes.filter(
+    const wallShapes = this.#document.shapes.filter((shape) => shape.kind === 'wall')
+    const openingShapes = this.#document.shapes.filter(
       (shape) => shape.kind === 'door' || shape.kind === 'window' || shape.kind === 'gate'
     )
-    const symbolShapes = this.#shapes.filter((shape) => shape.kind === 'symbol')
-    const restShapes = this.#shapes.filter(
+    const symbolShapes = this.#document.shapes.filter((shape) => shape.kind === 'symbol')
+    const restShapes = this.#document.shapes.filter(
       (shape) =>
         shape.kind !== 'wall' &&
         shape.kind !== 'door' &&
@@ -3502,7 +3531,7 @@ export class CadleApp extends LiteElement {
       return entries.map((entry) => {
         if (entry.type === 'single') {
           const shape = entry.shape
-          return this.#shapeTemplate(shape, shape.id === this.#selectedId || this.#selectedIds.has(shape.id))
+          return this.#shapeTemplate(shape, shape.id === this.#document.selectedId || this.#document.selectedIds.has(shape.id))
         }
 
         return svg`
@@ -3510,7 +3539,7 @@ export class CadleApp extends LiteElement {
             ${repeat(
               entry.shapes,
               (shape) => shape.id,
-              (shape) => this.#shapeTemplate(shape, shape.id === this.#selectedId || this.#selectedIds.has(shape.id))
+              (shape) => this.#shapeTemplate(shape, shape.id === this.#document.selectedId || this.#document.selectedIds.has(shape.id))
             )}
           </g>
         `
@@ -3556,7 +3585,7 @@ export class CadleApp extends LiteElement {
   }
 
   #render() {
-    this.#publishNativeSelection(this.#shapeById(this.#selectedId))
+    this.#publishNativeSelection(this.#shapeById(this.#document.selectedId))
     this.#publishNativeControlsState()
     this.#primeSymbolSvgCache()
     this.requestRender()
@@ -3657,8 +3686,8 @@ export class CadleApp extends LiteElement {
         return
       case 'clear':
         if (!window.confirm('Clear the drawing?')) return
-        this.#shapes = []
-        this.#selectedId = null
+        this.#document.shapes = []
+        this.#document.selectedId = null
         this.#draft = null
         this.#drag = null
         this.#pushHistory()
@@ -3720,8 +3749,8 @@ export class CadleApp extends LiteElement {
       this.#wallChain = wallResult.wallChain
       this.#chainPreviewEnd = wallResult.chainPreviewEnd
       if (wallResult.committedWall) {
-        this.#shapes.push(wallResult.committedWall)
-        this.#selectedId = wallResult.committedWall.id
+        this.#document.shapes.push(wallResult.committedWall)
+        this.#document.selectedId = wallResult.committedWall.id
         this.#pushHistory()
       }
       this.#render()
@@ -3750,8 +3779,8 @@ export class CadleApp extends LiteElement {
             y: Number.isFinite(labelY) ? labelY - shapeCenter.y : 0
           }
         }
-        this.#selectedId = shapeId
-        this.#selectedIds = this.#expandSelectionWithGroup(shapeId)
+        this.#document.selectedId = shapeId
+        this.#document.selectedIds = this.#expandSelectionWithGroup(shapeId)
         this.#drag = null
         this.#bandStart = null
         this.#bandEnd = null
@@ -3771,7 +3800,7 @@ export class CadleApp extends LiteElement {
       !(this.#tools.current === 'symbol' && this.#pendingCatalogSymbol)
     ) {
       const expanded = this.#expandSelectionWithGroup(shapeId)
-      const next = new Set(this.#selectedIds.size ? this.#selectedIds : this.#selectedId ? [this.#selectedId] : [])
+      const next = new Set(this.#document.selectedIds.size ? this.#document.selectedIds : this.#document.selectedId ? [this.#document.selectedId] : [])
       const shouldRemove = [...expanded].every((id) => next.has(id))
 
       if (shouldRemove) {
@@ -3780,8 +3809,8 @@ export class CadleApp extends LiteElement {
         for (const id of expanded) next.add(id)
       }
 
-      this.#selectedIds = next
-      this.#selectedId = next.values().next().value ?? null
+      this.#document.selectedIds = next
+      this.#document.selectedId = next.values().next().value ?? null
       this.#drag = null
       this.#bandStart = null
       this.#bandEnd = null
@@ -3797,8 +3826,8 @@ export class CadleApp extends LiteElement {
       !(this.#tools.current === 'symbol' && this.#pendingCatalogSymbol)
     ) {
       if (shapeId === PROJECT_LOGO_SHAPE_ID && isProjectLogoVisible(this.#project)) {
-        this.#selectedIds = new Set([PROJECT_LOGO_SHAPE_ID])
-        this.#selectedId = PROJECT_LOGO_SHAPE_ID
+        this.#document.selectedIds = new Set([PROJECT_LOGO_SHAPE_ID])
+        this.#document.selectedId = PROJECT_LOGO_SHAPE_ID
         const logoBounds = this.#project ? getProjectLogoBounds(this.#project) : null
         this.#logoDrag =
           logoBounds !== null
@@ -3820,8 +3849,8 @@ export class CadleApp extends LiteElement {
       }
 
       const expanded = this.#expandSelectionWithGroup(shapeId)
-      this.#selectedIds = expanded
-      this.#selectedId = shapeId
+      this.#document.selectedIds = expanded
+      this.#document.selectedId = shapeId
       const dragIds = [...expanded]
       const initial = dragIds
         .map((id) => this.#shapeById(id))
@@ -3843,8 +3872,8 @@ export class CadleApp extends LiteElement {
     if (this.#tools.current === 'text') {
       const value = window.prompt('Text', 'Label')?.trim()
       if (!value) return
-      this.#shapes.push(createTextShape(nextShapeId(), rawPoint, value))
-      this.#selectedId = this.#shapes[this.#shapes.length - 1]?.id ?? null
+      this.#document.shapes.push(createTextShape(nextShapeId(), rawPoint, value))
+      this.#document.selectedId = this.#document.shapes[this.#document.shapes.length - 1]?.id ?? null
       this.#pushHistory()
       this.#render()
       return
@@ -3944,9 +3973,9 @@ export class CadleApp extends LiteElement {
       })
       if (!onewire) return
 
-      this.#shapes.push(...onewire.shapes)
-      this.#selectedId = onewire.selectedId
-      this.#selectedIds = onewire.selectedIds
+      this.#document.shapes.push(...onewire.shapes)
+      this.#document.selectedId = onewire.selectedId
+      this.#document.selectedIds = onewire.selectedIds
       this.#oneWireBindingId = onewire.nextBindingId
       this.#oneWireLastPoint = placementPoint
 
@@ -3961,7 +3990,7 @@ export class CadleApp extends LiteElement {
         } else {
           const busBarId = nextShapeId()
           this.#oneWireBusBarId = busBarId
-          this.#shapes.push({ id: busBarId, kind: 'line', start: busStart, end: busEnd } as LineShape)
+          this.#document.shapes.push({ id: busBarId, kind: 'line', start: busStart, end: busEnd } as LineShape)
         }
       }
 
@@ -3974,15 +4003,15 @@ export class CadleApp extends LiteElement {
       const selectResult = resolveSelectPointerDownState({
         shapeId,
         rawPoint,
-        selectedIds: this.#selectedIds,
-        selectedId: this.#selectedId,
-        shapes: this.#shapes,
+        selectedIds: this.#document.selectedIds,
+        selectedId: this.#document.selectedId,
+        shapes: this.#document.shapes,
         pointerId: event.pointerId
       })
       if (shapeId) {
         const expanded = this.#expandSelectionWithGroup(shapeId)
-        this.#selectedIds = expanded
-        this.#selectedId = shapeId
+        this.#document.selectedIds = expanded
+        this.#document.selectedId = shapeId
         const dragIds = [...expanded]
         const initial = dragIds
           .map((id) => this.#shapeById(id))
@@ -3997,8 +4026,8 @@ export class CadleApp extends LiteElement {
         this.#bandEnd = null
         this.#stagePointerId = event.pointerId
       } else {
-        this.#selectedIds = selectResult.selectedIds
-        this.#selectedId = selectResult.selectedId
+        this.#document.selectedIds = selectResult.selectedIds
+        this.#document.selectedId = selectResult.selectedId
         this.#drag = selectResult.drag
         this.#bandStart = selectResult.bandStart
         this.#bandEnd = selectResult.bandEnd
@@ -4062,7 +4091,7 @@ export class CadleApp extends LiteElement {
 
     const drag = this.#drag
     if (drag && this.#stagePointerId === event.pointerId) {
-      const movedShapes = applyDragMove(rawPoint, drag, (point) => this.#snapPoint(point), this.#shapes)
+      const movedShapes = applyDragMove(rawPoint, drag, (point) => this.#snapPoint(point), this.#document.shapes)
       this.#setShapes(movedShapes)
       this.#render()
       return
@@ -4249,9 +4278,9 @@ export class CadleApp extends LiteElement {
       if (this.#pendingCatalogSymbol) {
         const shape = createSymbolShape(nextShapeId(), placement.anchor, this.#pendingCatalogSymbol)
         if (placement.rotation) shape.rotation = placement.rotation
-        this.#shapes.push(shape)
-        this.#selectedId = shape.id
-        this.#selectedIds = new Set([shape.id])
+        this.#document.shapes.push(shape)
+        this.#document.selectedId = shape.id
+        this.#document.selectedIds = new Set([shape.id])
         this.#pendingCatalogSymbol = null
         this.#symbolPreviewPoint = null
         this.#snapTarget = null
@@ -4279,8 +4308,8 @@ export class CadleApp extends LiteElement {
 
     if (phase === 'band' && this.#bandStart && this.#bandEnd) {
       const ids = this.#shapesInBand(this.#bandStart, this.#bandEnd)
-      this.#selectedIds = new Set(ids)
-      this.#selectedId = ids[0] ?? null
+      this.#document.selectedIds = new Set(ids)
+      this.#document.selectedId = ids[0] ?? null
       this.#bandStart = null
       this.#bandEnd = null
       this.#stagePointerId = null
@@ -4296,9 +4325,9 @@ export class CadleApp extends LiteElement {
           draftShape.kind === 'door' || draftShape.kind === 'window' || draftShape.kind === 'gate'
             ? this.#bindOpeningToWall(draftShape)
             : draftShape
-        this.#shapes.push(committedShape)
-        this.#selectedId = committedShape.id
-        this.#selectedIds = new Set([committedShape.id])
+        this.#document.shapes.push(committedShape)
+        this.#document.selectedId = committedShape.id
+        this.#document.selectedIds = new Set([committedShape.id])
         this.#pushHistory()
       }
       this.#draft = null

--- a/src/app.ts
+++ b/src/app.ts
@@ -48,7 +48,11 @@ import type {
   Tool
 } from './native-draw/types.js'
 import type { Project, UUID } from './types.js'
-import { setProjectData } from './api/project.js'
+import {
+  electricalMetadataFromCatalog,
+  type ElectricalDeviceMetadata
+} from './native-draw/electrical.js'
+import { getProjectData, setProjectData } from './api/project.js'
 import pubsub from './pubsub.js'
 import { downloadTextFile } from './native-app/export/downloads.js'
 import {
@@ -102,6 +106,7 @@ import {
   circuitBomRows,
   type CircuitAnalysis,
   type CircuitComponent,
+  type CircuitGroup,
   type BomRow
 } from './native-app/circuit-analysis.js'
 import { ViewportController } from './native-app/controllers/viewport-controller.js'
@@ -176,6 +181,7 @@ export class CadleApp extends LiteElement {
   #pageKey: UUID | null = null
   #project: Project | null = null
   #persistPromise: Promise<void> = Promise.resolve()
+  #circuitUpdatePromise: Promise<void> = Promise.resolve()
   #persistError: unknown = null
   #initializePromise: Promise<void> = Promise.resolve()
   #connected = false
@@ -607,6 +613,22 @@ export class CadleApp extends LiteElement {
       }
     }
 
+    const selectedShape = this.#shapeById(this.#document.selectedId)
+    const circuitGroup = selectedShape ? this.#circuitGroupForShape(selectedShape) : null
+    if (payload.electrical && circuitGroup) {
+      const { role, circuitType, oneWireEligible, ratedCurrentA, ...circuitProperties } = payload.electrical
+      if (Object.keys(circuitProperties).length > 0) {
+        this.#circuitUpdatePromise = this.#circuitUpdatePromise.then(() =>
+          this.#updateCircuitProperties(circuitGroup.bindingId, circuitProperties)
+        )
+        return
+      }
+      void role
+      void circuitType
+      void oneWireEligible
+      void ratedCurrentA
+    }
+
     const nextShapes = updateSelectionProperties(this.#document.shapes, payload, {
       selectedIds: this.#document.selectedIds,
       selectedId: this.#document.selectedId,
@@ -717,6 +739,10 @@ export class CadleApp extends LiteElement {
   async flushPendingSave(): Promise<void> {
     await this.#persistPromise
     if (this.#persistError) throw this.#persistError
+  }
+
+  async flushPendingCircuitUpdates(): Promise<void> {
+    await this.#circuitUpdatePromise
   }
 
   #persist() {
@@ -2443,7 +2469,14 @@ export class CadleApp extends LiteElement {
           .filter((group) => group.family === family)
           .map((group) => group.specification.breakerCurrentA)
       )
-      this.#addKamrailCircuitBundle(rail, x, { amps: familyCurrent, family, autoIncludeFamily: true })
+      const familyGroups = analysis.groups.filter((group) => group.family === family)
+      this.#addKamrailCircuitBundle(rail, x, {
+        amps: familyCurrent,
+        poles: Math.max(...familyGroups.map((group) => group.specification.poles)),
+        phaseConfiguration: familyGroups.some((group) => group.specification.phaseConfiguration === 'three-phase') ? 'three-phase' : 'single-phase',
+        family,
+        autoIncludeFamily: true
+      })
     })
 
     const freshGenerated = this.#document.shapes.slice(retainedShapes.length)
@@ -2461,7 +2494,7 @@ export class CadleApp extends LiteElement {
 
   #groundplanComponentsForFamily(
     family: string
-  ): Array<{ bindingId: string; kind: 'switch' | 'load'; sourceShapeId: string; sourcePath?: string; sourceName?: string }> {
+  ): Array<{ bindingId: string; kind: 'switch' | 'load'; sourceShapeId: string; sourcePath?: string; sourceName?: string; breakerCurrentA: number; cableSectionMm2: number; poles: number; breakerCurve?: string }> {
     return this.analyzeBindings()
       .groups.filter((group) => group.family === family)
       .flatMap((group) =>
@@ -2474,6 +2507,10 @@ export class CadleApp extends LiteElement {
             bindingId: group.bindingId,
             kind: component.role,
             sourceShapeId: component.shapeId,
+            breakerCurrentA: group.specification.breakerCurrentA,
+            cableSectionMm2: group.specification.cableSectionMm2,
+            poles: group.specification.poles,
+            breakerCurve: group.specification.breakerCurve,
             sourcePath: component.path,
             sourceName: component.name
           }))
@@ -2483,7 +2520,7 @@ export class CadleApp extends LiteElement {
   #addKamrailCircuitBundle(
     rail: LineShape,
     anchorX: number,
-    options: { amps: number; family: string; autoIncludeFamily: boolean }
+    options: { amps: number; poles?: number; phaseConfiguration?: 'single-phase' | 'three-phase'; family: string; autoIncludeFamily: boolean }
   ): boolean {
     const familyComponents = options.autoIncludeFamily ? this.#groundplanComponentsForFamily(options.family) : []
     const result = buildKamrailCircuitBundle({
@@ -2766,6 +2803,93 @@ export class CadleApp extends LiteElement {
     return safeAreaTemplate(this.#safeAreaRect())
   }
 
+  #circuitGroupForShape(shape: Shape): CircuitGroup | null {
+    const analysis = this.analyzeBindings()
+    if (shape.sourceLink?.kind === 'device') {
+      return analysis.groups.find((group) => group.components.some((item) => item.shapeId === shape.sourceLink?.id)) ?? null
+    }
+    if (shape.sourceLink?.kind === 'circuit') {
+      return analysis.groups.find((group) => group.bindingId === shape.sourceLink?.id) ?? null
+    }
+    const binding = shape.bindingId?.trim().toUpperCase()
+    if (binding) {
+      const exact = analysis.groups.find((group) => group.bindingId === binding)
+      if (exact) return exact
+      const familyMatches = analysis.groups.filter((group) => group.family === binding)
+      if (familyMatches.length === 1) return familyMatches[0]
+    }
+    if (shape.sourceLink?.kind === 'board') {
+      const familyMatches = analysis.groups.filter((group) => group.family === shape.sourceLink?.id)
+      if (familyMatches.length === 1) return familyMatches[0]
+    }
+    return null
+  }
+
+  #effectiveCircuitElectrical(shape: Shape, group: CircuitGroup): ElectricalDeviceMetadata {
+    const component = shape.sourceLink?.kind === 'device'
+      ? group.components.find((item) => item.shapeId === shape.sourceLink?.id)
+      : undefined
+    const base = shape.kind === 'symbol'
+      ? (shape.electrical ?? electricalMetadataFromCatalog(undefined, shape.name, shape.path))
+      : { role: component?.role ?? 'neutral', oneWireEligible: true }
+    return {
+      ...base,
+      role: component?.role ?? (shape.sourceLink?.role === 'breaker' ? 'protection' : base.role),
+      oneWireEligible: true,
+      circuitType: group.specification.circuitType,
+      breakerCurrentA: group.specification.breakerCurrentA,
+      cableSectionMm2: group.specification.cableSectionMm2,
+      poles: group.specification.poles,
+      phaseConfiguration: group.specification.phaseConfiguration,
+      breakerCurve: group.specification.breakerCurve ?? 'C',
+      rcdSensitivityMa: group.specification.rcdSensitivityMa,
+      rcdType: group.specification.rcdType,
+      boardId: group.specification.boardId ?? 'main',
+      railId: group.specification.railId ?? 'rail-1',
+      notes: group.specification.notes
+    }
+  }
+
+  async #updateCircuitProperties(
+    bindingId: string,
+    update: Partial<{ [K in keyof ElectricalDeviceMetadata]: ElectricalDeviceMetadata[K] | null }>
+  ): Promise<void> {
+    if (!this.#projectKey || !this.#project) return
+    const apply = (shape: Shape): Shape => {
+      if (shape.kind !== 'symbol' || shape.bindingId?.trim().toUpperCase() !== bindingId) return shape
+      const electrical = { ...(shape.electrical ?? electricalMetadataFromCatalog(undefined, shape.name, shape.path)) }
+      for (const [key, value] of Object.entries(update)) {
+        if (value === null || value === undefined) delete (electrical as Record<string, unknown>)[key]
+        else (electrical as Record<string, unknown>)[key] = value
+      }
+      return { ...shape, electrical }
+    }
+
+    const currentPageType = this.#pageKey ? this.#project.pages[this.#pageKey]?.pageType : undefined
+    if (currentPageType !== 'onewire') {
+      this.#document.shapes = this.#document.shapes.map(apply)
+      this.#pushHistory()
+      this.#render()
+      await this.flushPendingSave()
+    }
+
+    for (const pageKey of Object.keys(this.#project.pages) as UUID[]) {
+      if (this.#project.pages[pageKey]?.pageType === 'onewire') continue
+      if (pageKey === this.#pageKey) continue
+      const state = this.#nativeStateForPage(pageKey)
+      if (!state || !Array.isArray(state.shapes)) continue
+      const nextState = { ...state, shapes: sanitizeShapes(state.shapes).map(apply), selectedId: null } as NativeDocumentState
+      await saveNativeState(this.#projectKey, pageKey, nextState)
+    }
+    this.#project = await getProjectData(this.#projectKey)
+    if (currentPageType !== 'onewire') return
+    const oneWirePages = Object.entries(this.#project.pages)
+      .filter(([, page]) => page.pageType === 'onewire')
+      .sort(([, left], [, right]) => (left.order ?? 0) - (right.order ?? 0))
+    const pageIndex = Math.max(0, oneWirePages.findIndex(([key]) => key === this.#pageKey))
+    this.generateAutoOneWire(pageIndex)
+  }
+
   #rubberBandTemplate() {
     return rubberBandTemplate(this.#bandStart, this.#bandEnd)
   }
@@ -2804,11 +2928,18 @@ export class CadleApp extends LiteElement {
     }
 
     const groupedSelection = this.#selectedGroupId()
+    const circuitGroup = selectedShape ? this.#circuitGroupForShape(selectedShape) : null
+    const effectiveElectrical = selectedShape && circuitGroup
+      ? this.#effectiveCircuitElectrical(selectedShape, circuitGroup)
+      : undefined
+    const isProtectionText = selectedShape?.kind === 'symbol' && /automaat|breaker|protection devices/i.test(`${selectedShape.name} ${selectedShape.path}`)
     pubsub.publish(
       'native.selection.changed',
       createNativeSelectionChangedPayload(selectedShape, groupedSelection ? 1 : this.#document.selectedIds.size, {
         kindOverride: groupedSelection ? 'group' : undefined,
-        bindingIdOverride: groupedSelection ? this.#selectedGroupBindingId() : undefined
+        bindingIdOverride: groupedSelection ? this.#selectedGroupBindingId() : circuitGroup?.bindingId,
+        electricalOverride: effectiveElectrical,
+        hideSymbolTextFields: Boolean(circuitGroup && isProtectionText)
       })
     )
   }

--- a/src/elements/modals/project-details-dialog.css
+++ b/src/elements/modals/project-details-dialog.css
@@ -57,6 +57,16 @@
   padding: 18px 20px;
 }
 
+.form-section {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 12px;
+  padding-top: 16px;
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+}
+
 .form-grid label {
   display: flex;
   flex-direction: column;
@@ -68,7 +78,8 @@
   color: var(--md-sys-color-on-surface-variant);
 }
 
-.form-grid input {
+.form-grid input,
+.form-grid select {
   border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--cadle-radius-sm);
   padding: 8px 10px;
@@ -78,7 +89,8 @@
   outline: none;
 }
 
-.form-grid input:focus {
+.form-grid input:focus,
+.form-grid select:focus {
   border-color: var(--md-sys-color-primary);
   box-shadow: var(--cadle-focus-ring);
 }

--- a/src/elements/modals/project-details-dialog.ts
+++ b/src/elements/modals/project-details-dialog.ts
@@ -36,6 +36,11 @@ export class ProjectDetailsDialog extends LiteElement {
   @property({ type: String }) accessor phaseConfiguration: 'single-phase' | 'three-phase' = 'single-phase'
   @property({ type: String }) accessor earthingSystem: 'TT' | 'TN' | 'IT' | 'unknown' = 'unknown'
   @property({ type: Number }) accessor defaultPoles = 2
+  @property({ type: String }) accessor boardName = 'Main distribution board'
+  @property({ type: Number }) accessor mainRcdCurrentA = 40
+  @property({ type: Number }) accessor mainRcdSensitivityMa = 300
+  @property({ type: Number }) accessor mainRcdPoles = 2
+  @property({ type: String }) accessor mainRcdType: 'AC' | 'A' | 'F' | 'B' | 'other' = 'A'
 
   static styles = [styles]
 
@@ -78,6 +83,12 @@ export class ProjectDetailsDialog extends LiteElement {
     this.phaseConfiguration = profile.phaseConfiguration
     this.earthingSystem = profile.earthingSystem
     this.defaultPoles = profile.defaultPoles
+    const board = profile.boards?.[0]
+    this.boardName = board?.name ?? 'Main distribution board'
+    this.mainRcdCurrentA = board?.mainDifferential?.ratedCurrentA ?? 40
+    this.mainRcdSensitivityMa = board?.mainDifferential?.sensitivityMa ?? 300
+    this.mainRcdPoles = board?.mainDifferential?.poles ?? profile.defaultPoles
+    this.mainRcdType = board?.mainDifferential?.type ?? 'A'
   }
 
   #close = () => {
@@ -159,6 +170,21 @@ export class ProjectDetailsDialog extends LiteElement {
         break
       case 'defaultPoles':
         this.defaultPoles = Math.max(1, Number(value) || 2)
+        break
+      case 'boardName':
+        this.boardName = value
+        break
+      case 'mainRcdCurrentA':
+        this.mainRcdCurrentA = Math.max(1, Number(value) || 40)
+        break
+      case 'mainRcdSensitivityMa':
+        this.mainRcdSensitivityMa = Math.max(1, Number(value) || 300)
+        break
+      case 'mainRcdPoles':
+        this.mainRcdPoles = Math.max(1, Number(value) || 2)
+        break
+      case 'mainRcdType':
+        this.mainRcdType = value === 'AC' || value === 'F' || value === 'B' || value === 'other' ? value : 'A'
         break
       default:
         break
@@ -255,7 +281,16 @@ export class ProjectDetailsDialog extends LiteElement {
       supplyVoltageV: this.supplyVoltageV,
       phaseConfiguration: this.phaseConfiguration,
       earthingSystem: this.earthingSystem,
-      defaultPoles: this.defaultPoles
+      defaultPoles: this.defaultPoles,
+      boards: [{
+        id: 'main',
+        name: this.boardName.trim() || 'Main distribution board',
+        rails: [{ id: 'rail-1', name: 'Rail 1' }],
+        mainDifferential: {
+          id: 'main-rcd', ratedCurrentA: this.mainRcdCurrentA, sensitivityMa: this.mainRcdSensitivityMa,
+          poles: this.mainRcdPoles, type: this.mainRcdType
+        }
+      }]
     })
 
     await setProjectData(this.projectKey, nextProject)
@@ -461,6 +496,12 @@ export class ProjectDetailsDialog extends LiteElement {
             <span>Standaard aantal polen</span>
             <input type="number" min="1" step="1" .value=${String(this.defaultPoles)} data-field="defaultPoles" @input=${this.#onMetaInput} />
           </label>
+          <div class="form-section"><strong>Verdeelbord en hoofddifferentieel</strong></div>
+          <label><span>Naam bord</span><input .value=${this.boardName} data-field="boardName" @input=${this.#onMetaInput} /></label>
+          <label><span>Nominale stroom (A)</span><input type="number" min="1" .value=${String(this.mainRcdCurrentA)} data-field="mainRcdCurrentA" @input=${this.#onMetaInput} /></label>
+          <label><span>Gevoeligheid (mA)</span><input type="number" min="1" .value=${String(this.mainRcdSensitivityMa)} data-field="mainRcdSensitivityMa" @input=${this.#onMetaInput} /></label>
+          <label><span>Polen</span><input type="number" min="1" .value=${String(this.mainRcdPoles)} data-field="mainRcdPoles" @input=${this.#onMetaInput} /></label>
+          <label><span>Type</span><select .value=${this.mainRcdType} data-field="mainRcdType" @change=${this.#onMetaInput}><option value="AC">AC</option><option value="A">A</option><option value="F">F</option><option value="B">B</option><option value="other">Andere</option></select></label>
         </div>
         <div class="footer">
           <button

--- a/src/elements/modals/project-details-dialog.ts
+++ b/src/elements/modals/project-details-dialog.ts
@@ -2,6 +2,7 @@ import { LiteElement, html, customElement, property } from '@vandeurenglenn/lite
 import styles from './project-details-dialog.css' with { type: 'css' }
 import type { Project, Projects, UUID } from '../../types.js'
 import { getProjectData, getProjects, set, setProjectData } from '../../api/project.js'
+import { normalizeElectricalProfile } from '../../native-app/electrical-profile.js'
 
 type ProjectDetailsSavedDetail = {
   project: Project
@@ -28,6 +29,11 @@ export class ProjectDetailsDialog extends LiteElement {
   @property({ type: String }) accessor logoUrl = ''
   @property({ type: String }) accessor logoColor = ''
   @property({ type: Number }) accessor logoScale = 1
+  @property({ type: String }) accessor electricalEdition = ''
+  @property({ type: Number }) accessor supplyVoltageV = 230
+  @property({ type: String }) accessor phaseConfiguration: 'single-phase' | 'three-phase' = 'single-phase'
+  @property({ type: String }) accessor earthingSystem: 'TT' | 'TN' | 'IT' | 'unknown' = 'unknown'
+  @property({ type: Number }) accessor defaultPoles = 2
 
   static styles = [styles]
 
@@ -62,6 +68,12 @@ export class ProjectDetailsDialog extends LiteElement {
     this.installerBtw = this.project?.installer?.btw ?? ''
     this.eanCode = this.project?.eanCode ?? ''
     this.mainFuseA = this.project?.mainFuseA ?? 0
+    const profile = normalizeElectricalProfile(this.project?.electricalProfile)
+    this.electricalEdition = profile.edition
+    this.supplyVoltageV = profile.supplyVoltageV
+    this.phaseConfiguration = profile.phaseConfiguration
+    this.earthingSystem = profile.earthingSystem
+    this.defaultPoles = profile.defaultPoles
   }
 
   #close = () => {
@@ -114,6 +126,21 @@ export class ProjectDetailsDialog extends LiteElement {
         break
       case 'logoScale':
         this.logoScale = Math.max(0.4, Math.min(2.5, Number(value) || 1))
+        break
+      case 'electricalEdition':
+        this.electricalEdition = value
+        break
+      case 'supplyVoltageV':
+        this.supplyVoltageV = Math.max(1, Number(value) || 230)
+        break
+      case 'phaseConfiguration':
+        this.phaseConfiguration = value === 'three-phase' ? 'three-phase' : 'single-phase'
+        break
+      case 'earthingSystem':
+        this.earthingSystem = value === 'TT' || value === 'TN' || value === 'IT' ? value : 'unknown'
+        break
+      case 'defaultPoles':
+        this.defaultPoles = Math.max(1, Number(value) || 2)
         break
       default:
         break
@@ -202,6 +229,14 @@ export class ProjectDetailsDialog extends LiteElement {
     nextProject.installer.btw = this.installerBtw.trim() || undefined
     nextProject.eanCode = this.eanCode.trim() || undefined
     nextProject.mainFuseA = this.mainFuseA > 0 ? this.mainFuseA : undefined
+    nextProject.electricalProfile = normalizeElectricalProfile({
+      standard: 'AREI',
+      edition: this.electricalEdition,
+      supplyVoltageV: this.supplyVoltageV,
+      phaseConfiguration: this.phaseConfiguration,
+      earthingSystem: this.earthingSystem,
+      defaultPoles: this.defaultPoles
+    })
 
     await setProjectData(this.projectKey, nextProject)
     await set(this.projectKey, nextProject.name)
@@ -362,6 +397,36 @@ export class ProjectDetailsDialog extends LiteElement {
               data-field="mainFuseA"
               @input=${this.#onMetaInput}
               placeholder="40" />
+          </label>
+          <div class="form-section">
+            <strong>Elektrisch profiel</strong>
+            <span>AREI-georiënteerde projectdefaults; controleer de actuele uitgave en installatiegegevens.</span>
+          </div>
+          <label><span>Norm</span><input value="AREI" disabled /></label>
+          <label>
+            <span>Uitgave / referentie</span>
+            <input .value=${this.electricalEdition} data-field="electricalEdition" @input=${this.#onMetaInput} />
+          </label>
+          <label>
+            <span>Netspanning (V)</span>
+            <input type="number" min="1" .value=${String(this.supplyVoltageV)} data-field="supplyVoltageV" @input=${this.#onMetaInput} />
+          </label>
+          <label>
+            <span>Fasen</span>
+            <select .value=${this.phaseConfiguration} data-field="phaseConfiguration" @change=${this.#onMetaInput}>
+              <option value="single-phase">Monofasig</option><option value="three-phase">Driefasig</option>
+            </select>
+          </label>
+          <label>
+            <span>Aardingsstelsel</span>
+            <select .value=${this.earthingSystem} data-field="earthingSystem" @change=${this.#onMetaInput}>
+              <option value="unknown">Nog te bevestigen</option><option value="TT">TT</option>
+              <option value="TN">TN</option><option value="IT">IT</option>
+            </select>
+          </label>
+          <label>
+            <span>Standaard aantal polen</span>
+            <input type="number" min="1" step="1" .value=${String(this.defaultPoles)} data-field="defaultPoles" @input=${this.#onMetaInput} />
           </label>
         </div>
         <div class="footer">

--- a/src/elements/modals/project-details-dialog.ts
+++ b/src/elements/modals/project-details-dialog.ts
@@ -30,6 +30,8 @@ export class ProjectDetailsDialog extends LiteElement {
   @property({ type: String }) accessor logoColor = ''
   @property({ type: Number }) accessor logoScale = 1
   @property({ type: String }) accessor electricalEdition = ''
+  @property({ type: String }) accessor distributor = ''
+  @property({ type: String }) accessor supplyConfiguration: '1x230V+N' | '3x230V' | '3x400V+N' | 'other' = '1x230V+N'
   @property({ type: Number }) accessor supplyVoltageV = 230
   @property({ type: String }) accessor phaseConfiguration: 'single-phase' | 'three-phase' = 'single-phase'
   @property({ type: String }) accessor earthingSystem: 'TT' | 'TN' | 'IT' | 'unknown' = 'unknown'
@@ -70,6 +72,8 @@ export class ProjectDetailsDialog extends LiteElement {
     this.mainFuseA = this.project?.mainFuseA ?? 0
     const profile = normalizeElectricalProfile(this.project?.electricalProfile)
     this.electricalEdition = profile.edition
+    this.distributor = profile.distributor
+    this.supplyConfiguration = profile.supplyConfiguration
     this.supplyVoltageV = profile.supplyVoltageV
     this.phaseConfiguration = profile.phaseConfiguration
     this.earthingSystem = profile.earthingSystem
@@ -130,6 +134,20 @@ export class ProjectDetailsDialog extends LiteElement {
       case 'electricalEdition':
         this.electricalEdition = value
         break
+      case 'distributor':
+        this.distributor = value
+        break
+      case 'supplyConfiguration': {
+        const configuration =
+          value === '3x230V' || value === '3x400V+N' || value === 'other' ? value : '1x230V+N'
+        this.supplyConfiguration = configuration
+        if (configuration !== 'other') {
+          this.supplyVoltageV = configuration === '3x400V+N' ? 400 : 230
+          this.phaseConfiguration = configuration === '1x230V+N' ? 'single-phase' : 'three-phase'
+          this.defaultPoles = configuration === '3x400V+N' ? 4 : configuration === '3x230V' ? 3 : 2
+        }
+        break
+      }
       case 'supplyVoltageV':
         this.supplyVoltageV = Math.max(1, Number(value) || 230)
         break
@@ -232,6 +250,8 @@ export class ProjectDetailsDialog extends LiteElement {
     nextProject.electricalProfile = normalizeElectricalProfile({
       standard: 'AREI',
       edition: this.electricalEdition,
+      distributor: this.distributor,
+      supplyConfiguration: this.supplyConfiguration,
       supplyVoltageV: this.supplyVoltageV,
       phaseConfiguration: this.phaseConfiguration,
       earthingSystem: this.earthingSystem,
@@ -403,6 +423,19 @@ export class ProjectDetailsDialog extends LiteElement {
             <span>AREI-georiënteerde projectdefaults; controleer de actuele uitgave en installatiegegevens.</span>
           </div>
           <label><span>Norm</span><input value="AREI" disabled /></label>
+          <label>
+            <span>Distributienetbeheerder</span>
+            <input .value=${this.distributor} data-field="distributor" @input=${this.#onMetaInput} placeholder="bv. Fluvius" />
+          </label>
+          <label>
+            <span>Netaansluiting</span>
+            <select .value=${this.supplyConfiguration} data-field="supplyConfiguration" @change=${this.#onMetaInput}>
+              <option value="1x230V+N">1 × 230 V (L + N)</option>
+              <option value="3x230V">3 × 230 V (L1 + L2 + L3)</option>
+              <option value="3x400V+N">3 × 400 V + N (L1 + L2 + L3 + N)</option>
+              <option value="other">Andere / handmatig</option>
+            </select>
+          </label>
           <label>
             <span>Uitgave / referentie</span>
             <input .value=${this.electricalEdition} data-field="electricalEdition" @input=${this.#onMetaInput} />

--- a/src/elements/modals/validation-report.ts
+++ b/src/elements/modals/validation-report.ts
@@ -18,6 +18,12 @@ type ValidationGroup = {
     cableSectionMm2: number
     poles: number
     phaseConfiguration: 'single-phase' | 'three-phase'
+    breakerCurve?: string
+    rcdSensitivityMa?: number
+    rcdType?: string
+    boardId?: string
+    railId?: string
+    notes?: string
     source: 'explicit' | 'suggested'
     sources: {
       breakerCurrentA: 'entered' | 'suggested'
@@ -129,6 +135,12 @@ export class ValidationReportModal extends LiteElement {
                           ${group.specification.phaseConfiguration === 'three-phase' ? '3-phase' : '1-phase'}
                           (${group.specification.sources.phaseConfiguration})
                         </div>
+                        <div>
+                          ${group.specification.breakerCurve ? `Curve ${group.specification.breakerCurve}` : 'Curve not set'} •
+                          ${group.specification.rcdSensitivityMa ? `${group.specification.rcdSensitivityMa} mA ${group.specification.rcdType ?? ''}` : 'RCD not assigned'} •
+                          ${group.specification.boardId ?? 'main'} / ${group.specification.railId ?? 'rail-1'}
+                        </div>
+                        ${group.specification.notes ? html`<div>${group.specification.notes}</div>` : ''}
                       `
                     : ''}
                 </div>

--- a/src/elements/modals/validation-report.ts
+++ b/src/elements/modals/validation-report.ts
@@ -13,6 +13,19 @@ type ValidationGroup = {
   switches: number
   loads: number
   neutral: number
+  specification?: {
+    breakerCurrentA: number
+    cableSectionMm2: number
+    poles: number
+    phaseConfiguration: 'single-phase' | 'three-phase'
+    source: 'explicit' | 'suggested'
+    sources: {
+      breakerCurrentA: 'entered' | 'suggested'
+      cableSectionMm2: 'entered' | 'suggested'
+      poles: 'entered' | 'project' | 'suggested'
+      phaseConfiguration: 'entered' | 'project' | 'suggested'
+    }
+  }
 }
 
 export type ValidationReport = {
@@ -65,6 +78,14 @@ export class ValidationReportModal extends LiteElement {
             <div class="stat"><strong>${report.errorCount}</strong><span>Errors</span></div>
             <div class="stat"><strong>${report.warningCount}</strong><span>Warnings</span></div>
           </div>
+          <div class="group">
+            <strong>AREI-oriented preflight</strong>
+            <div>
+              This check catches missing drawing data and conflicting circuit values. Suggested protection and cable
+              values must still be confirmed by the designer and the completed installation remains subject to an
+              authorised inspection.
+            </div>
+          </div>
           <div class="issues">
             <div class="row">
               <strong>Issues</strong>
@@ -99,18 +120,33 @@ export class ValidationReportModal extends LiteElement {
                     <span class="pill ${group.ready ? 'ok' : 'warn'}">${group.ready ? 'ready' : 'incomplete'}</span>
                   </div>
                   <div>${group.switches} switches • ${group.loads} loads/sockets • ${group.neutral} other</div>
+                  ${group.specification
+                    ? html`
+                        <div>
+                          ${group.specification.breakerCurrentA} A (${group.specification.sources.breakerCurrentA}) •
+                          ${group.specification.cableSectionMm2} mm² (${group.specification.sources.cableSectionMm2}) •
+                          ${group.specification.poles}P (${group.specification.sources.poles}) •
+                          ${group.specification.phaseConfiguration === 'three-phase' ? '3-phase' : '1-phase'}
+                          (${group.specification.sources.phaseConfiguration})
+                        </div>
+                      `
+                    : ''}
                 </div>
               `
             )}
           </div>
         </div>
         <div class="footer">
-          <div>${report.valid ? 'Validation passed.' : 'Fix issues or continue when you are ready.'}</div>
+          <div>
+            ${report.valid
+              ? 'Preflight passed. Confirm suggested values before inspection.'
+              : 'Fix the errors before generating the one-wire diagram.'}
+          </div>
           <div class="footer-actions">
             <button @click=${this.#close}>Done</button>
             <button
               class="primary"
-              ?disabled=${report.totalGroups === 0}
+              ?disabled=${!report.valid}
               @click=${this.#generateOneWire}>
               Generate One-Wire
             </button>

--- a/src/elements/panes/object-pane.css
+++ b/src/elements/panes/object-pane.css
@@ -172,6 +172,25 @@ custom-button:active {
   color: var(--md-sys-color-on-surface-variant);
 }
 
+.native-section-title {
+  margin-top: var(--cadle-space-4);
+  padding-top: var(--cadle-space-3);
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  font: var(--md-sys-typescale-title-small);
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+}
+
+.native-row > label {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.native-row > label > .native-label {
+  display: block;
+  margin-bottom: 6px;
+}
+
 .native-input {
   width: 100%;
   box-sizing: border-box;

--- a/src/elements/panes/object-pane.ts
+++ b/src/elements/panes/object-pane.ts
@@ -5,6 +5,7 @@ import { buildKlemmenlijstTSV, buildLabelSheetHTML, downloadText } from './../..
 import type { PanelLabelRow } from '../../helpers/panel-labels.js'
 import { normalizeSelection, type BindingLabelSide, type SelectionPayload, type SelectionShapeElectrical, type SymbolTextField } from './object-pane/selection-model.js'
 import { GOOGLE_FONTS_URL, SYSTEM_FONTS } from './object-pane/text-options.js'
+import { circuitDefaults } from '../../native-app/circuit-defaults.js'
 import '../header.js'
 import '@vandeurenglenn/flex-elements/it.js'
 import '@vandeurenglenn/lite-elements/icon-button.js'
@@ -167,16 +168,16 @@ export class ObjectPane extends LiteElement {
     this._nativeBindingLabelSide = shape.bindingLabelSide
     if (shape.kind === 'symbol') {
       const electrical = shape.electrical ?? {}
-      const socketOrMotor = electrical.circuitType === 'sockets' || electrical.circuitType === 'motor' || electrical.circuitType === 'mixed'
+      const defaults = circuitDefaults(electrical.circuitType)
       this._nativeElectrical = {
         ...electrical,
-        breakerCurrentA: electrical.breakerCurrentA ?? (socketOrMotor ? 20 : 16),
-        cableSectionMm2: electrical.cableSectionMm2 ?? (socketOrMotor ? 2.5 : 1.5),
-        poles: electrical.poles ?? 2,
-        phaseConfiguration: electrical.phaseConfiguration ?? 'single-phase',
-        breakerCurve: electrical.breakerCurve ?? 'C',
-        boardId: electrical.boardId ?? 'main',
-        railId: electrical.railId ?? 'rail-1'
+        breakerCurrentA: electrical.breakerCurrentA ?? defaults.breakerCurrentA,
+        cableSectionMm2: electrical.cableSectionMm2 ?? defaults.cableSectionMm2,
+        poles: electrical.poles ?? defaults.poles,
+        phaseConfiguration: electrical.phaseConfiguration ?? defaults.phaseConfiguration,
+        breakerCurve: electrical.breakerCurve ?? defaults.breakerCurve,
+        boardId: electrical.boardId ?? defaults.boardId,
+        railId: electrical.railId ?? defaults.railId
       }
     } else {
       this._nativeElectrical = null
@@ -340,19 +341,16 @@ export class ObjectPane extends LiteElement {
 
   #effectiveElectrical = (): SelectionShapeElectrical => {
     const electrical = this._nativeElectrical ?? {}
-    const socketOrMotor =
-      electrical.circuitType === 'sockets' ||
-      electrical.circuitType === 'motor' ||
-      electrical.circuitType === 'mixed'
+    const defaults = circuitDefaults(electrical.circuitType)
     return {
       ...electrical,
-      breakerCurrentA: electrical.breakerCurrentA ?? (socketOrMotor ? 20 : 16),
-      cableSectionMm2: electrical.cableSectionMm2 ?? (socketOrMotor ? 2.5 : 1.5),
-      poles: electrical.poles ?? 2,
-      phaseConfiguration: electrical.phaseConfiguration ?? 'single-phase',
-      breakerCurve: electrical.breakerCurve ?? 'C',
-      boardId: electrical.boardId ?? 'main',
-      railId: electrical.railId ?? 'rail-1'
+      breakerCurrentA: electrical.breakerCurrentA ?? defaults.breakerCurrentA,
+      cableSectionMm2: electrical.cableSectionMm2 ?? defaults.cableSectionMm2,
+      poles: electrical.poles ?? defaults.poles,
+      phaseConfiguration: electrical.phaseConfiguration ?? defaults.phaseConfiguration,
+      breakerCurve: electrical.breakerCurve ?? defaults.breakerCurve,
+      boardId: electrical.boardId ?? defaults.boardId,
+      railId: electrical.railId ?? defaults.railId
     }
   }
 
@@ -434,17 +432,17 @@ export class ObjectPane extends LiteElement {
                 <option value="">Infer from symbol</option><option value="lighting">Lighting</option><option value="sockets">Sockets</option><option value="motor">Motor</option><option value="mixed">Mixed</option><option value="other">Other</option>
               </select>
               <div class="native-row">
-                <label><span class="native-label">Breaker (A)</span><input data-electrical-field="breakerCurrentA" class="native-input" type="number" min="1" value=${String(this.#effectiveElectrical().breakerCurrentA ?? '')} @change=${(event: Event) => this.#updateElectrical('breakerCurrentA', (event.target as HTMLInputElement).value)} /></label>
-                <label><span class="native-label">Cable (mm²)</span><input data-electrical-field="cableSectionMm2" class="native-input" type="number" min="0.1" step="0.1" value=${String(this.#effectiveElectrical().cableSectionMm2 ?? '')} @change=${(event: Event) => this.#updateElectrical('cableSectionMm2', (event.target as HTMLInputElement).value)} /></label>
+                <label><span class="native-label">Breaker (A)</span><input data-electrical-field="breakerCurrentA" class="native-input" type="number" min="1" .value=${String(this.#effectiveElectrical().breakerCurrentA ?? '')} @change=${(event: Event) => this.#updateElectrical('breakerCurrentA', (event.target as HTMLInputElement).value)} /></label>
+                <label><span class="native-label">Cable (mm²)</span><input data-electrical-field="cableSectionMm2" class="native-input" type="number" min="0.1" step="0.1" .value=${String(this.#effectiveElectrical().cableSectionMm2 ?? '')} @change=${(event: Event) => this.#updateElectrical('cableSectionMm2', (event.target as HTMLInputElement).value)} /></label>
               </div>
               <div class="native-row">
-                <label><span class="native-label">Poles</span><input data-electrical-field="poles" class="native-input" type="number" min="1" step="1" value=${String(this.#effectiveElectrical().poles ?? '')} @change=${(event: Event) => this.#updateElectrical('poles', (event.target as HTMLInputElement).value)} /></label>
+                <label><span class="native-label">Poles</span><input data-electrical-field="poles" class="native-input" type="number" min="1" step="1" .value=${String(this.#effectiveElectrical().poles ?? '')} @change=${(event: Event) => this.#updateElectrical('poles', (event.target as HTMLInputElement).value)} /></label>
                 <label><span class="native-label">Phase</span><select class="native-select" .value=${this.#effectiveElectrical().phaseConfiguration ?? ''} @change=${(event: Event) => this.#updateElectrical('phaseConfiguration', (event.target as HTMLSelectElement).value)}><option value="">Project default</option><option value="single-phase">Single-phase</option><option value="three-phase">Three-phase</option></select></label>
               </div>
               <div class="native-note">Values apply to this symbol and are used for its bound circuit.</div>
               <div class="native-row">
                 <label><span class="native-label">Breaker curve</span><select data-electrical-field="breakerCurve" class="native-select" .value=${this.#effectiveElectrical().breakerCurve ?? ''} @change=${(event: Event) => this.#updateElectrical('breakerCurve', (event.target as HTMLSelectElement).value)}><option value="">Not set</option><option value="B">B</option><option value="C">C</option><option value="D">D</option><option value="other">Other</option></select></label>
-                <label><span class="native-label">RCD (mA)</span><input class="native-input" type="number" min="1" value=${String(this.#effectiveElectrical().rcdSensitivityMa ?? '')} @change=${(event: Event) => this.#updateElectrical('rcdSensitivityMa', (event.target as HTMLInputElement).value)} /></label>
+                <label><span class="native-label">RCD (mA)</span><input class="native-input" type="number" min="1" .value=${String(this.#effectiveElectrical().rcdSensitivityMa ?? '')} @change=${(event: Event) => this.#updateElectrical('rcdSensitivityMa', (event.target as HTMLInputElement).value)} /></label>
               </div>
               <div class="native-row">
                 <label><span class="native-label">RCD type</span><select class="native-select" .value=${this.#effectiveElectrical().rcdType ?? ''} @change=${(event: Event) => this.#updateElectrical('rcdType', (event.target as HTMLSelectElement).value)}><option value="">Not set</option><option value="AC">AC</option><option value="A">A</option><option value="F">F</option><option value="B">B</option><option value="other">Other</option></select></label>

--- a/src/elements/panes/object-pane.ts
+++ b/src/elements/panes/object-pane.ts
@@ -3,7 +3,7 @@ import pubsub from '../../pubsub.js'
 import styles from './object-pane.css' with { type: 'css' }
 import { buildKlemmenlijstTSV, buildLabelSheetHTML, downloadText } from './../../helpers/panel-labels.js'
 import type { PanelLabelRow } from '../../helpers/panel-labels.js'
-import { normalizeSelection, type BindingLabelSide, type SelectionPayload, type SymbolTextField } from './object-pane/selection-model.js'
+import { normalizeSelection, type BindingLabelSide, type SelectionPayload, type SelectionShapeElectrical, type SymbolTextField } from './object-pane/selection-model.js'
 import { GOOGLE_FONTS_URL, SYSTEM_FONTS } from './object-pane/text-options.js'
 import '../header.js'
 import '@vandeurenglenn/flex-elements/it.js'
@@ -81,6 +81,9 @@ export class ObjectPane extends LiteElement {
   @property({ type: String, attribute: false })
   private accessor _nativeBindingLabelSide: BindingLabelSide = 'right'
 
+  @property({ attribute: false })
+  private accessor _nativeElectrical: SelectionShapeElectrical | null = null
+
   @query('.native-binding-input')
   private accessor _nativeBindingInput!: HTMLInputElement
 
@@ -136,6 +139,7 @@ export class ObjectPane extends LiteElement {
       this._nativeFontFamily = ''
       this._nativeLetterSpacing = null
       this._nativeBindingLabelSide = 'auto'
+      this._nativeElectrical = null
       return
     }
 
@@ -161,6 +165,7 @@ export class ObjectPane extends LiteElement {
     this._nativeFontFamily = shape.fontFamily
     this._nativeLetterSpacing = shape.letterSpacing
     this._nativeBindingLabelSide = shape.bindingLabelSide
+    this._nativeElectrical = shape.electrical
     this._activeObjectLabel = shape.label
   }
 
@@ -310,6 +315,14 @@ export class ObjectPane extends LiteElement {
     pubsub.publish('native.object.update', { letterSpacing: raw })
   }
 
+  #updateElectrical = (field: keyof SelectionShapeElectrical, value: string) => {
+    const numericFields = new Set(['breakerCurrentA', 'cableSectionMm2', 'poles'])
+    const parsed = numericFields.has(field) ? (value.trim() ? Number(value) : null) : value || null
+    if (typeof parsed === 'number' && (!Number.isFinite(parsed) || parsed <= 0)) return
+    this._nativeElectrical = { ...(this._nativeElectrical ?? {}), [field]: parsed ?? undefined }
+    pubsub.publish('native.object.update', { electrical: { [field]: parsed } })
+  }
+
   #flipNativeShape = () => {
     if (!this._nativeCanFlip) return
     pubsub.publish('native.object.flip-side', {})
@@ -376,6 +389,28 @@ export class ObjectPane extends LiteElement {
           @input=${this.#onNativeBindingInput}
           @change=${this.#saveNativeBinding}
           placeholder="e.g. Q1" />
+        ${!multiple && this._nativeSelectedKind === 'symbol'
+          ? html`
+              <div class="native-section-title">Circuit properties</div>
+              <label class="native-label">Role</label>
+              <select class="native-select" .value=${this._nativeElectrical?.role ?? ''} @change=${(event: Event) => this.#updateElectrical('role', (event.target as HTMLSelectElement).value)}>
+                <option value="">Not classified</option><option value="switch">Switch</option><option value="load">Load</option><option value="protection">Protection</option><option value="junction">Junction</option><option value="neutral">Other</option>
+              </select>
+              <label class="native-label">Circuit type</label>
+              <select class="native-select" .value=${this._nativeElectrical?.circuitType ?? ''} @change=${(event: Event) => this.#updateElectrical('circuitType', (event.target as HTMLSelectElement).value)}>
+                <option value="">Infer from symbol</option><option value="lighting">Lighting</option><option value="sockets">Sockets</option><option value="motor">Motor</option><option value="mixed">Mixed</option><option value="other">Other</option>
+              </select>
+              <div class="native-row">
+                <label><span class="native-label">Breaker (A)</span><input class="native-input" type="number" min="1" .value=${String(this._nativeElectrical?.breakerCurrentA ?? '')} @change=${(event: Event) => this.#updateElectrical('breakerCurrentA', (event.target as HTMLInputElement).value)} /></label>
+                <label><span class="native-label">Cable (mm²)</span><input class="native-input" type="number" min="0.1" step="0.1" .value=${String(this._nativeElectrical?.cableSectionMm2 ?? '')} @change=${(event: Event) => this.#updateElectrical('cableSectionMm2', (event.target as HTMLInputElement).value)} /></label>
+              </div>
+              <div class="native-row">
+                <label><span class="native-label">Poles</span><input class="native-input" type="number" min="1" step="1" .value=${String(this._nativeElectrical?.poles ?? '')} @change=${(event: Event) => this.#updateElectrical('poles', (event.target as HTMLInputElement).value)} /></label>
+                <label><span class="native-label">Phase</span><select class="native-select" .value=${this._nativeElectrical?.phaseConfiguration ?? ''} @change=${(event: Event) => this.#updateElectrical('phaseConfiguration', (event.target as HTMLSelectElement).value)}><option value="">Project default</option><option value="single-phase">Single-phase</option><option value="three-phase">Three-phase</option></select></label>
+              </div>
+              <div class="native-note">Values apply to this symbol and are used for its bound circuit.</div>
+            `
+          : ''}
         <label class="native-label">Label position</label>
         <div
           class="native-chip-row"

--- a/src/elements/panes/object-pane.ts
+++ b/src/elements/panes/object-pane.ts
@@ -316,7 +316,7 @@ export class ObjectPane extends LiteElement {
   }
 
   #updateElectrical = (field: keyof SelectionShapeElectrical, value: string) => {
-    const numericFields = new Set(['breakerCurrentA', 'cableSectionMm2', 'poles'])
+    const numericFields = new Set(['breakerCurrentA', 'cableSectionMm2', 'poles', 'rcdSensitivityMa'])
     const parsed = numericFields.has(field) ? (value.trim() ? Number(value) : null) : value || null
     if (typeof parsed === 'number' && (!Number.isFinite(parsed) || parsed <= 0)) return
     this._nativeElectrical = { ...(this._nativeElectrical ?? {}), [field]: parsed ?? undefined }
@@ -409,6 +409,16 @@ export class ObjectPane extends LiteElement {
                 <label><span class="native-label">Phase</span><select class="native-select" .value=${this._nativeElectrical?.phaseConfiguration ?? ''} @change=${(event: Event) => this.#updateElectrical('phaseConfiguration', (event.target as HTMLSelectElement).value)}><option value="">Project default</option><option value="single-phase">Single-phase</option><option value="three-phase">Three-phase</option></select></label>
               </div>
               <div class="native-note">Values apply to this symbol and are used for its bound circuit.</div>
+              <div class="native-row">
+                <label><span class="native-label">Breaker curve</span><select class="native-select" .value=${this._nativeElectrical?.breakerCurve ?? ''} @change=${(event: Event) => this.#updateElectrical('breakerCurve', (event.target as HTMLSelectElement).value)}><option value="">Not set</option><option value="B">B</option><option value="C">C</option><option value="D">D</option><option value="other">Other</option></select></label>
+                <label><span class="native-label">RCD (mA)</span><input class="native-input" type="number" min="1" .value=${String(this._nativeElectrical?.rcdSensitivityMa ?? '')} @change=${(event: Event) => this.#updateElectrical('rcdSensitivityMa', (event.target as HTMLInputElement).value)} /></label>
+              </div>
+              <div class="native-row">
+                <label><span class="native-label">RCD type</span><select class="native-select" .value=${this._nativeElectrical?.rcdType ?? ''} @change=${(event: Event) => this.#updateElectrical('rcdType', (event.target as HTMLSelectElement).value)}><option value="">Not set</option><option value="AC">AC</option><option value="A">A</option><option value="F">F</option><option value="B">B</option><option value="other">Other</option></select></label>
+                <label><span class="native-label">Board</span><input class="native-input" .value=${this._nativeElectrical?.boardId ?? ''} @change=${(event: Event) => this.#updateElectrical('boardId', (event.target as HTMLInputElement).value)} placeholder="main" /></label>
+              </div>
+              <label class="native-label">Rail</label><input class="native-input" .value=${this._nativeElectrical?.railId ?? ''} @change=${(event: Event) => this.#updateElectrical('railId', (event.target as HTMLInputElement).value)} placeholder="rail-1" />
+              <label class="native-label">Circuit notes</label><textarea class="native-input" .value=${this._nativeElectrical?.notes ?? ''} @change=${(event: Event) => this.#updateElectrical('notes', (event.target as HTMLTextAreaElement).value)}></textarea>
             `
           : ''}
         <label class="native-label">Label position</label>

--- a/src/elements/panes/object-pane.ts
+++ b/src/elements/panes/object-pane.ts
@@ -165,7 +165,22 @@ export class ObjectPane extends LiteElement {
     this._nativeFontFamily = shape.fontFamily
     this._nativeLetterSpacing = shape.letterSpacing
     this._nativeBindingLabelSide = shape.bindingLabelSide
-    this._nativeElectrical = shape.electrical
+    if (shape.kind === 'symbol') {
+      const electrical = shape.electrical ?? {}
+      const socketOrMotor = electrical.circuitType === 'sockets' || electrical.circuitType === 'motor' || electrical.circuitType === 'mixed'
+      this._nativeElectrical = {
+        ...electrical,
+        breakerCurrentA: electrical.breakerCurrentA ?? (socketOrMotor ? 20 : 16),
+        cableSectionMm2: electrical.cableSectionMm2 ?? (socketOrMotor ? 2.5 : 1.5),
+        poles: electrical.poles ?? 2,
+        phaseConfiguration: electrical.phaseConfiguration ?? 'single-phase',
+        breakerCurve: electrical.breakerCurve ?? 'C',
+        boardId: electrical.boardId ?? 'main',
+        railId: electrical.railId ?? 'rail-1'
+      }
+    } else {
+      this._nativeElectrical = null
+    }
     this._activeObjectLabel = shape.label
   }
 
@@ -323,6 +338,24 @@ export class ObjectPane extends LiteElement {
     pubsub.publish('native.object.update', { electrical: { [field]: parsed } })
   }
 
+  #effectiveElectrical = (): SelectionShapeElectrical => {
+    const electrical = this._nativeElectrical ?? {}
+    const socketOrMotor =
+      electrical.circuitType === 'sockets' ||
+      electrical.circuitType === 'motor' ||
+      electrical.circuitType === 'mixed'
+    return {
+      ...electrical,
+      breakerCurrentA: electrical.breakerCurrentA ?? (socketOrMotor ? 20 : 16),
+      cableSectionMm2: electrical.cableSectionMm2 ?? (socketOrMotor ? 2.5 : 1.5),
+      poles: electrical.poles ?? 2,
+      phaseConfiguration: electrical.phaseConfiguration ?? 'single-phase',
+      breakerCurve: electrical.breakerCurve ?? 'C',
+      boardId: electrical.boardId ?? 'main',
+      railId: electrical.railId ?? 'rail-1'
+    }
+  }
+
   #flipNativeShape = () => {
     if (!this._nativeCanFlip) return
     pubsub.publish('native.object.flip-side', {})
@@ -393,32 +426,32 @@ export class ObjectPane extends LiteElement {
           ? html`
               <div class="native-section-title">Circuit properties</div>
               <label class="native-label">Role</label>
-              <select class="native-select" .value=${this._nativeElectrical?.role ?? ''} @change=${(event: Event) => this.#updateElectrical('role', (event.target as HTMLSelectElement).value)}>
+              <select class="native-select" .value=${this.#effectiveElectrical().role ?? ''} @change=${(event: Event) => this.#updateElectrical('role', (event.target as HTMLSelectElement).value)}>
                 <option value="">Not classified</option><option value="switch">Switch</option><option value="load">Load</option><option value="protection">Protection</option><option value="junction">Junction</option><option value="neutral">Other</option>
               </select>
               <label class="native-label">Circuit type</label>
-              <select class="native-select" .value=${this._nativeElectrical?.circuitType ?? ''} @change=${(event: Event) => this.#updateElectrical('circuitType', (event.target as HTMLSelectElement).value)}>
+              <select class="native-select" .value=${this.#effectiveElectrical().circuitType ?? ''} @change=${(event: Event) => this.#updateElectrical('circuitType', (event.target as HTMLSelectElement).value)}>
                 <option value="">Infer from symbol</option><option value="lighting">Lighting</option><option value="sockets">Sockets</option><option value="motor">Motor</option><option value="mixed">Mixed</option><option value="other">Other</option>
               </select>
               <div class="native-row">
-                <label><span class="native-label">Breaker (A)</span><input class="native-input" type="number" min="1" .value=${String(this._nativeElectrical?.breakerCurrentA ?? '')} @change=${(event: Event) => this.#updateElectrical('breakerCurrentA', (event.target as HTMLInputElement).value)} /></label>
-                <label><span class="native-label">Cable (mm²)</span><input class="native-input" type="number" min="0.1" step="0.1" .value=${String(this._nativeElectrical?.cableSectionMm2 ?? '')} @change=${(event: Event) => this.#updateElectrical('cableSectionMm2', (event.target as HTMLInputElement).value)} /></label>
+                <label><span class="native-label">Breaker (A)</span><input data-electrical-field="breakerCurrentA" class="native-input" type="number" min="1" value=${String(this.#effectiveElectrical().breakerCurrentA ?? '')} @change=${(event: Event) => this.#updateElectrical('breakerCurrentA', (event.target as HTMLInputElement).value)} /></label>
+                <label><span class="native-label">Cable (mm²)</span><input data-electrical-field="cableSectionMm2" class="native-input" type="number" min="0.1" step="0.1" value=${String(this.#effectiveElectrical().cableSectionMm2 ?? '')} @change=${(event: Event) => this.#updateElectrical('cableSectionMm2', (event.target as HTMLInputElement).value)} /></label>
               </div>
               <div class="native-row">
-                <label><span class="native-label">Poles</span><input class="native-input" type="number" min="1" step="1" .value=${String(this._nativeElectrical?.poles ?? '')} @change=${(event: Event) => this.#updateElectrical('poles', (event.target as HTMLInputElement).value)} /></label>
-                <label><span class="native-label">Phase</span><select class="native-select" .value=${this._nativeElectrical?.phaseConfiguration ?? ''} @change=${(event: Event) => this.#updateElectrical('phaseConfiguration', (event.target as HTMLSelectElement).value)}><option value="">Project default</option><option value="single-phase">Single-phase</option><option value="three-phase">Three-phase</option></select></label>
+                <label><span class="native-label">Poles</span><input data-electrical-field="poles" class="native-input" type="number" min="1" step="1" value=${String(this.#effectiveElectrical().poles ?? '')} @change=${(event: Event) => this.#updateElectrical('poles', (event.target as HTMLInputElement).value)} /></label>
+                <label><span class="native-label">Phase</span><select class="native-select" .value=${this.#effectiveElectrical().phaseConfiguration ?? ''} @change=${(event: Event) => this.#updateElectrical('phaseConfiguration', (event.target as HTMLSelectElement).value)}><option value="">Project default</option><option value="single-phase">Single-phase</option><option value="three-phase">Three-phase</option></select></label>
               </div>
               <div class="native-note">Values apply to this symbol and are used for its bound circuit.</div>
               <div class="native-row">
-                <label><span class="native-label">Breaker curve</span><select class="native-select" .value=${this._nativeElectrical?.breakerCurve ?? ''} @change=${(event: Event) => this.#updateElectrical('breakerCurve', (event.target as HTMLSelectElement).value)}><option value="">Not set</option><option value="B">B</option><option value="C">C</option><option value="D">D</option><option value="other">Other</option></select></label>
-                <label><span class="native-label">RCD (mA)</span><input class="native-input" type="number" min="1" .value=${String(this._nativeElectrical?.rcdSensitivityMa ?? '')} @change=${(event: Event) => this.#updateElectrical('rcdSensitivityMa', (event.target as HTMLInputElement).value)} /></label>
+                <label><span class="native-label">Breaker curve</span><select data-electrical-field="breakerCurve" class="native-select" .value=${this.#effectiveElectrical().breakerCurve ?? ''} @change=${(event: Event) => this.#updateElectrical('breakerCurve', (event.target as HTMLSelectElement).value)}><option value="">Not set</option><option value="B">B</option><option value="C">C</option><option value="D">D</option><option value="other">Other</option></select></label>
+                <label><span class="native-label">RCD (mA)</span><input class="native-input" type="number" min="1" value=${String(this.#effectiveElectrical().rcdSensitivityMa ?? '')} @change=${(event: Event) => this.#updateElectrical('rcdSensitivityMa', (event.target as HTMLInputElement).value)} /></label>
               </div>
               <div class="native-row">
-                <label><span class="native-label">RCD type</span><select class="native-select" .value=${this._nativeElectrical?.rcdType ?? ''} @change=${(event: Event) => this.#updateElectrical('rcdType', (event.target as HTMLSelectElement).value)}><option value="">Not set</option><option value="AC">AC</option><option value="A">A</option><option value="F">F</option><option value="B">B</option><option value="other">Other</option></select></label>
-                <label><span class="native-label">Board</span><input class="native-input" .value=${this._nativeElectrical?.boardId ?? ''} @change=${(event: Event) => this.#updateElectrical('boardId', (event.target as HTMLInputElement).value)} placeholder="main" /></label>
+                <label><span class="native-label">RCD type</span><select class="native-select" .value=${this.#effectiveElectrical().rcdType ?? ''} @change=${(event: Event) => this.#updateElectrical('rcdType', (event.target as HTMLSelectElement).value)}><option value="">Not set</option><option value="AC">AC</option><option value="A">A</option><option value="F">F</option><option value="B">B</option><option value="other">Other</option></select></label>
+                <label><span class="native-label">Board</span><input class="native-input" .value=${this.#effectiveElectrical().boardId ?? ''} @change=${(event: Event) => this.#updateElectrical('boardId', (event.target as HTMLInputElement).value)} placeholder="main" /></label>
               </div>
-              <label class="native-label">Rail</label><input class="native-input" .value=${this._nativeElectrical?.railId ?? ''} @change=${(event: Event) => this.#updateElectrical('railId', (event.target as HTMLInputElement).value)} placeholder="rail-1" />
-              <label class="native-label">Circuit notes</label><textarea class="native-input" .value=${this._nativeElectrical?.notes ?? ''} @change=${(event: Event) => this.#updateElectrical('notes', (event.target as HTMLTextAreaElement).value)}></textarea>
+              <label class="native-label">Rail</label><input class="native-input" .value=${this.#effectiveElectrical().railId ?? ''} @change=${(event: Event) => this.#updateElectrical('railId', (event.target as HTMLInputElement).value)} placeholder="rail-1" />
+              <label class="native-label">Circuit notes</label><textarea class="native-input" .value=${this.#effectiveElectrical().notes ?? ''} @change=${(event: Event) => this.#updateElectrical('notes', (event.target as HTMLTextAreaElement).value)}></textarea>
             `
           : ''}
         <label class="native-label">Label position</label>

--- a/src/elements/panes/object-pane/selection-model.ts
+++ b/src/elements/panes/object-pane/selection-model.ts
@@ -37,6 +37,12 @@ export type SelectionShape = {
     cableSectionMm2?: number
     poles?: number
     phaseConfiguration?: string
+    breakerCurve?: string
+    rcdSensitivityMa?: number
+    rcdType?: string
+    boardId?: string
+    railId?: string
+    notes?: string
   }
 }
 

--- a/src/elements/panes/object-pane/selection-model.ts
+++ b/src/elements/panes/object-pane/selection-model.ts
@@ -6,6 +6,8 @@ export type SymbolTextField = {
   value: string
 }
 
+export type SelectionShapeElectrical = NonNullable<SelectionShape['electrical']>
+
 export type SelectionShape = {
   id?: string
   kind?: string
@@ -28,6 +30,14 @@ export type SelectionShape = {
   x?: number
   y?: number
   bindingLabelOffset?: { x: number; y: number }
+  electrical?: {
+    role?: string
+    circuitType?: string
+    breakerCurrentA?: number
+    cableSectionMm2?: number
+    poles?: number
+    phaseConfiguration?: string
+  }
 }
 
 export type SelectionPayload = {
@@ -87,7 +97,8 @@ export const normalizeSelection = (payload: SelectionPayload) => {
       y: finiteNumber(shape.y),
       fontFamily: typeof shape.fontFamily === 'string' ? shape.fontFamily : '',
       letterSpacing: finiteNumber(shape.letterSpacing),
-      bindingLabelSide: inferBindingLabelSide(shape.bindingLabelOffset ?? null)
+      bindingLabelSide: inferBindingLabelSide(shape.bindingLabelOffset ?? null),
+      electrical: shape.electrical && typeof shape.electrical === 'object' ? { ...shape.electrical } : null
     }
   }
 }

--- a/src/fields/projects.css
+++ b/src/fields/projects.css
@@ -8,6 +8,18 @@
   box-sizing: border-box;
   background: var(--md-sys-color-background);
 }
+.welcome-dialog {
+  max-width: min(560px, calc(100vw - 32px));
+}
+.welcome-dialog-content {
+  display: grid;
+  gap: var(--cadle-space-3);
+  color: var(--md-sys-color-on-surface-variant);
+}
+.welcome-dialog-content p {
+  margin: 0;
+  line-height: 1.5;
+}
 .contextmenu {
   transform-origin: top right;
   border-radius: var(--md-sys-shape-corner-large);

--- a/src/fields/projects.ts
+++ b/src/fields/projects.ts
@@ -2,7 +2,10 @@ import { LiteElement, html, customElement, property, query } from '@vandeurengle
 import styles from './projects.css' with { type: 'css' }
 import { Projects, type Project, type UUID } from './../types.js'
 import '@material/web/elevation/elevation.js'
+import '@material/web/dialog/dialog.js'
+import '@material/web/button/filled-button.js'
 import '@material/web/button/outlined-button.js'
+import '@material/web/button/text-button.js'
 import '@vandeurenglenn/lite-elements/dropdown.js'
 import '@vandeurenglenn/lite-elements/list-item.js'
 import '@vandeurenglenn/lite-elements/icon-button.js'
@@ -12,6 +15,8 @@ import { del, getProjects, renameProject, upload } from '../api/project.js'
 import pubsub from '../pubsub.js'
 @customElement('projects-field')
 export class ProjectsField extends LiteElement {
+  static readonly WELCOME_SEEN_STORAGE = 'cadle.welcomeSeen'
+
   @property({ attribute: false })
   accessor projects: Projects = []
 
@@ -23,6 +28,9 @@ export class ProjectsField extends LiteElement {
 
   @query('.contextmenu')
   accessor contextmenu!: CustomDropdown
+
+  @query('.welcome-dialog')
+  accessor welcomeDialog!: HTMLElement & { open: boolean; close?: () => void }
 
   _currentSelected
   _transitionEnd?: () => void
@@ -41,6 +49,12 @@ export class ProjectsField extends LiteElement {
     this.showReopenPreviousProjectPrompt = Boolean(shell.showReopenPreviousProjectPrompt)
     this.previousProjectName = String(shell.previousProjectName ?? '')
     pubsub.subscribe('shell.reopen-previous-project-prompt', this.#onReopenPreviousProjectPrompt)
+    if (this.projects.length === 0 && !localStorage.getItem(ProjectsField.WELCOME_SEEN_STORAGE)) {
+      localStorage.setItem(ProjectsField.WELCOME_SEEN_STORAGE, 'true')
+      requestAnimationFrame(() => {
+        if (this.welcomeDialog) this.welcomeDialog.open = true
+      })
+    }
   }
 
   disconnectedCallback(): void {
@@ -119,6 +133,21 @@ export class ProjectsField extends LiteElement {
   #dismissPreviousProjectPrompt = () => {
     const shell = cadleShell as unknown as { dismissReopenPreviousProjectPrompt?: () => void }
     shell.dismissReopenPreviousProjectPrompt?.()
+  }
+
+  #closeWelcome = () => {
+    if (this.welcomeDialog?.close) this.welcomeDialog.close()
+    else if (this.welcomeDialog) this.welcomeDialog.open = false
+  }
+
+  #createFirstProject = () => {
+    this.#closeWelcome()
+    location.hash = '#!/create-project'
+  }
+
+  #uploadFirstProject = () => {
+    this.#closeWelcome()
+    void upload()
   }
 
   _loadProject(key: string, projectName: string) {
@@ -322,6 +351,18 @@ export class ProjectsField extends LiteElement {
 
   render() {
     return html`
+      <md-dialog class="welcome-dialog">
+        <div slot="headline">Hello, welcome to Cadle</div>
+        <div slot="content" class="welcome-dialog-content">
+          <p>Cadle helps you build a ground plan and turn its circuits into a clear AREI one-wire diagram.</p>
+          <p>Start a new project, or upload an existing Cadle project to continue working.</p>
+        </div>
+        <div slot="actions">
+          <md-text-button @click=${this.#closeWelcome}>Maybe later</md-text-button>
+          <md-outlined-button @click=${this.#uploadFirstProject}>Upload project</md-outlined-button>
+          <md-filled-button @click=${this.#createFirstProject}>Create project</md-filled-button>
+        </div>
+      </md-dialog>
       <custom-dropdown class="contextmenu">
         <custom-list-item
           data-action="editProjectDetails"

--- a/src/native-app/circuit-analysis.ts
+++ b/src/native-app/circuit-analysis.ts
@@ -106,7 +106,7 @@ const suggestedSpecification = (
     cableSectionMm2: explicitSection ?? (socketOrMotor ? 2.5 : 1.5),
     poles: explicitPoles ?? profile?.defaultPoles ?? ((explicitPhase ?? profile?.phaseConfiguration) === 'three-phase' ? 4 : 2),
     phaseConfiguration: explicitPhase ?? profile?.phaseConfiguration ?? 'single-phase',
-    ...(explicitCurve ? { breakerCurve: explicitCurve } : {}),
+    breakerCurve: explicitCurve ?? 'C',
     ...(explicitRcd ? { rcdSensitivityMa: explicitRcd } : {}),
     ...(explicitRcdType ? { rcdType: explicitRcdType } : {}),
     ...(boardId ? { boardId } : {}),

--- a/src/native-app/circuit-analysis.ts
+++ b/src/native-app/circuit-analysis.ts
@@ -1,5 +1,6 @@
 import type { Shape, SymbolShape } from '../native-draw/types.js'
 import { inferCircuitType, inferElectricalRole, type ElectricalCircuitType } from '../native-draw/electrical.js'
+import type { ElectricalProjectProfile } from '../types.js'
 
 export type CircuitComponentRole = 'switch' | 'load' | 'protection' | 'junction' | 'neutral'
 
@@ -10,6 +11,12 @@ export type CircuitSpecification = {
   poles: number
   phaseConfiguration: 'single-phase' | 'three-phase'
   source: 'explicit' | 'suggested'
+  sources: {
+    breakerCurrentA: 'entered' | 'suggested'
+    cableSectionMm2: 'entered' | 'suggested'
+    poles: 'entered' | 'project' | 'suggested'
+    phaseConfiguration: 'entered' | 'project' | 'suggested'
+  }
 }
 
 export type CircuitComponent = {
@@ -68,7 +75,11 @@ export const inferCircuitRole = (shape: Shape): CircuitComponentRole => {
   return shape.electrical?.role ?? inferElectricalRole(shape.name, shape.path)
 }
 
-const suggestedSpecification = (components: CircuitComponent[], symbols: SymbolShape[]): CircuitSpecification => {
+const suggestedSpecification = (
+  components: CircuitComponent[],
+  symbols: SymbolShape[],
+  profile?: ElectricalProjectProfile
+): CircuitSpecification => {
   const explicitCurrent = symbols.map((shape) => shape.electrical?.breakerCurrentA).find((value) => value !== undefined)
   const explicitSection = symbols.map((shape) => shape.electrical?.cableSectionMm2).find((value) => value !== undefined)
   const explicitPoles = symbols.map((shape) => shape.electrical?.poles).find((value) => value !== undefined)
@@ -81,12 +92,21 @@ const suggestedSpecification = (components: CircuitComponent[], symbols: SymbolS
     circuitType,
     breakerCurrentA: explicitCurrent ?? (socketOrMotor ? 20 : 16),
     cableSectionMm2: explicitSection ?? (socketOrMotor ? 2.5 : 1.5),
-    poles: explicitPoles ?? (explicitPhase === 'three-phase' ? 4 : 2),
-    phaseConfiguration: explicitPhase ?? 'single-phase',
+    poles: explicitPoles ?? profile?.defaultPoles ?? ((explicitPhase ?? profile?.phaseConfiguration) === 'three-phase' ? 4 : 2),
+    phaseConfiguration: explicitPhase ?? profile?.phaseConfiguration ?? 'single-phase',
     source:
-      explicitCurrent !== undefined || explicitSection !== undefined || explicitPoles !== undefined || explicitPhase !== undefined
+      explicitCurrent !== undefined &&
+      explicitSection !== undefined &&
+      explicitPoles !== undefined &&
+      explicitPhase !== undefined
         ? 'explicit'
-        : 'suggested'
+        : 'suggested',
+    sources: {
+      breakerCurrentA: explicitCurrent !== undefined ? 'entered' : 'suggested',
+      cableSectionMm2: explicitSection !== undefined ? 'entered' : 'suggested',
+      poles: explicitPoles !== undefined ? 'entered' : profile ? 'project' : 'suggested',
+      phaseConfiguration: explicitPhase !== undefined ? 'entered' : profile ? 'project' : 'suggested'
+    }
   }
 }
 
@@ -112,7 +132,7 @@ const conflictingSpecificationFields = (symbols: readonly SymbolShape[]): string
     .map(([, label]) => label)
 }
 
-export const analyzeCircuits = (shapes: readonly Shape[]): CircuitAnalysis => {
+export const analyzeCircuits = (shapes: readonly Shape[], profile?: ElectricalProjectProfile): CircuitAnalysis => {
   const grouped = new Map<string, CircuitComponent[]>()
   const issues: CircuitIssue[] = []
 
@@ -177,7 +197,7 @@ export const analyzeCircuits = (shapes: readonly Shape[]): CircuitAnalysis => {
         junctions,
         neutral,
         ready: loads > 0,
-        specification: suggestedSpecification(components, symbols)
+        specification: suggestedSpecification(components, symbols, profile)
       }
     })
     .sort((left, right) => left.family.localeCompare(right.family) || (left.number ?? 0) - (right.number ?? 0))

--- a/src/native-app/circuit-analysis.ts
+++ b/src/native-app/circuit-analysis.ts
@@ -1,6 +1,7 @@
 import type { Shape, SymbolShape } from '../native-draw/types.js'
 import { inferCircuitType, inferElectricalRole, type ElectricalCircuitType } from '../native-draw/electrical.js'
 import type { ElectricalProjectProfile } from '../types.js'
+import { circuitDefaults } from './circuit-defaults.js'
 
 export type CircuitComponentRole = 'switch' | 'load' | 'protection' | 'junction' | 'neutral'
 
@@ -96,17 +97,19 @@ const suggestedSpecification = (
   const boardId = symbols.map((shape) => shape.electrical?.boardId).find((value) => value !== undefined)
   const railId = symbols.map((shape) => shape.electrical?.railId).find((value) => value !== undefined)
   const notes = symbols.map((shape) => shape.electrical?.notes).find((value) => value !== undefined)
-  const types = new Set(components.map((component) => component.circuitType).filter(Boolean))
+  const loadComponents = components.filter((component) => component.role === 'load')
+  const typeSources = loadComponents.length > 0 ? loadComponents : components
+  const types = new Set(typeSources.map((component) => component.circuitType).filter(Boolean))
   const circuitType: ElectricalCircuitType =
     types.size > 1 ? 'mixed' : (([...types][0] as ElectricalCircuitType | undefined) ?? 'other')
-  const socketOrMotor = circuitType === 'sockets' || circuitType === 'motor' || circuitType === 'mixed'
+  const defaults = circuitDefaults(circuitType)
   return {
     circuitType,
-    breakerCurrentA: explicitCurrent ?? (socketOrMotor ? 20 : 16),
-    cableSectionMm2: explicitSection ?? (socketOrMotor ? 2.5 : 1.5),
+    breakerCurrentA: explicitCurrent ?? defaults.breakerCurrentA,
+    cableSectionMm2: explicitSection ?? defaults.cableSectionMm2,
     poles: explicitPoles ?? profile?.defaultPoles ?? ((explicitPhase ?? profile?.phaseConfiguration) === 'three-phase' ? 4 : 2),
     phaseConfiguration: explicitPhase ?? profile?.phaseConfiguration ?? 'single-phase',
-    breakerCurve: explicitCurve ?? 'C',
+    breakerCurve: explicitCurve ?? defaults.breakerCurve,
     ...(explicitRcd ? { rcdSensitivityMa: explicitRcd } : {}),
     ...(explicitRcdType ? { rcdType: explicitRcdType } : {}),
     ...(boardId ? { boardId } : {}),

--- a/src/native-app/circuit-analysis.ts
+++ b/src/native-app/circuit-analysis.ts
@@ -10,6 +10,12 @@ export type CircuitSpecification = {
   cableSectionMm2: number
   poles: number
   phaseConfiguration: 'single-phase' | 'three-phase'
+  breakerCurve?: 'B' | 'C' | 'D' | 'other'
+  rcdSensitivityMa?: number
+  rcdType?: 'AC' | 'A' | 'F' | 'B' | 'other'
+  boardId?: string
+  railId?: string
+  notes?: string
   source: 'explicit' | 'suggested'
   sources: {
     breakerCurrentA: 'entered' | 'suggested'
@@ -84,6 +90,12 @@ const suggestedSpecification = (
   const explicitSection = symbols.map((shape) => shape.electrical?.cableSectionMm2).find((value) => value !== undefined)
   const explicitPoles = symbols.map((shape) => shape.electrical?.poles).find((value) => value !== undefined)
   const explicitPhase = symbols.map((shape) => shape.electrical?.phaseConfiguration).find((value) => value !== undefined)
+  const explicitCurve = symbols.map((shape) => shape.electrical?.breakerCurve).find((value) => value !== undefined)
+  const explicitRcd = symbols.map((shape) => shape.electrical?.rcdSensitivityMa).find((value) => value !== undefined)
+  const explicitRcdType = symbols.map((shape) => shape.electrical?.rcdType).find((value) => value !== undefined)
+  const boardId = symbols.map((shape) => shape.electrical?.boardId).find((value) => value !== undefined)
+  const railId = symbols.map((shape) => shape.electrical?.railId).find((value) => value !== undefined)
+  const notes = symbols.map((shape) => shape.electrical?.notes).find((value) => value !== undefined)
   const types = new Set(components.map((component) => component.circuitType).filter(Boolean))
   const circuitType: ElectricalCircuitType =
     types.size > 1 ? 'mixed' : (([...types][0] as ElectricalCircuitType | undefined) ?? 'other')
@@ -94,6 +106,12 @@ const suggestedSpecification = (
     cableSectionMm2: explicitSection ?? (socketOrMotor ? 2.5 : 1.5),
     poles: explicitPoles ?? profile?.defaultPoles ?? ((explicitPhase ?? profile?.phaseConfiguration) === 'three-phase' ? 4 : 2),
     phaseConfiguration: explicitPhase ?? profile?.phaseConfiguration ?? 'single-phase',
+    ...(explicitCurve ? { breakerCurve: explicitCurve } : {}),
+    ...(explicitRcd ? { rcdSensitivityMa: explicitRcd } : {}),
+    ...(explicitRcdType ? { rcdType: explicitRcdType } : {}),
+    ...(boardId ? { boardId } : {}),
+    ...(railId ? { railId } : {}),
+    ...(notes ? { notes } : {}),
     source:
       explicitCurrent !== undefined &&
       explicitSection !== undefined &&
@@ -120,7 +138,12 @@ const conflictingSpecificationFields = (symbols: readonly SymbolShape[]): string
     ['breakerCurrentA', 'breaker current'],
     ['cableSectionMm2', 'cable section'],
     ['poles', 'pole count'],
-    ['phaseConfiguration', 'phase configuration']
+    ['phaseConfiguration', 'phase configuration'],
+    ['breakerCurve', 'breaker curve'],
+    ['rcdSensitivityMa', 'RCD sensitivity'],
+    ['rcdType', 'RCD type'],
+    ['boardId', 'board assignment'],
+    ['railId', 'rail assignment']
   ]
   return fields
     .filter(([field]) => {

--- a/src/native-app/circuit-defaults.ts
+++ b/src/native-app/circuit-defaults.ts
@@ -1,0 +1,24 @@
+import type { ElectricalCircuitType } from '../native-draw/electrical.js'
+
+export type CircuitDefaults = {
+  breakerCurrentA: number
+  cableSectionMm2: number
+  poles: number
+  phaseConfiguration: 'single-phase'
+  breakerCurve: 'C'
+  boardId: 'main'
+  railId: 'rail-1'
+}
+
+export const circuitDefaults = (circuitType?: ElectricalCircuitType | string): CircuitDefaults => {
+  const higherLoad = circuitType === 'sockets' || circuitType === 'motor' || circuitType === 'mixed'
+  return {
+    breakerCurrentA: higherLoad ? 20 : 16,
+    cableSectionMm2: higherLoad ? 2.5 : 1.5,
+    poles: 2,
+    phaseConfiguration: 'single-phase',
+    breakerCurve: 'C',
+    boardId: 'main',
+    railId: 'rail-1'
+  }
+}

--- a/src/native-app/controllers/canvas-document-controller.ts
+++ b/src/native-app/controllers/canvas-document-controller.ts
@@ -1,0 +1,25 @@
+import type { Shape } from '../../native-draw/types.js'
+import { DocumentHistory } from './document-history.js'
+
+export class CanvasDocumentController {
+  shapes: Shape[] = []
+  selectedId: string | null = null
+  selectedIds = new Set<string>()
+  readonly history = new DocumentHistory()
+
+  replaceShapes(shapes: readonly Shape[]): void {
+    this.shapes = [...shapes]
+    this.retainExistingSelection()
+  }
+
+  clearSelection(): void {
+    this.selectedId = null
+    this.selectedIds = new Set()
+  }
+
+  retainExistingSelection(): void {
+    const ids = new Set(this.shapes.map((shape) => shape.id))
+    this.selectedIds = new Set([...this.selectedIds].filter((id) => ids.has(id)))
+    if (this.selectedId && !ids.has(this.selectedId)) this.selectedId = null
+  }
+}

--- a/src/native-app/controllers/catalog-controller.ts
+++ b/src/native-app/controllers/catalog-controller.ts
@@ -1,0 +1,8 @@
+import type { Shape } from '../../native-draw/types.js'
+import { buildCatalogSelectionDraft } from '../layout/catalog-selection.js'
+
+export class CatalogController {
+  selectionDraft(shapes: readonly Shape[], selectedShapeIds: Iterable<string>) {
+    return buildCatalogSelectionDraft(shapes, selectedShapeIds)
+  }
+}

--- a/src/native-app/controllers/onewire-controller.ts
+++ b/src/native-app/controllers/onewire-controller.ts
@@ -1,0 +1,19 @@
+import type { Shape } from '../../native-draw/types.js'
+import type { ElectricalProjectProfile } from '../../types.js'
+import { analyzeCircuits } from '../circuit-analysis.js'
+import { planOneWireLayout, type OneWireFamilyDemand } from '../layout/onewire-layout-plan.js'
+import { reconcileGeneratedOneWire } from '../layout/onewire-regeneration.js'
+
+export class OneWireController {
+  analyze(shapes: readonly Shape[], profile?: ElectricalProjectProfile) {
+    return analyzeCircuits(shapes, profile)
+  }
+
+  plan(families: readonly OneWireFamilyDemand[], usableWidth: number, usableHeight: number) {
+    return planOneWireLayout(families, { usableWidth, usableHeight })
+  }
+
+  reconcile(previous: readonly Shape[], fresh: readonly Shape[]) {
+    return reconcileGeneratedOneWire(previous, fresh)
+  }
+}

--- a/src/native-app/electrical-profile.ts
+++ b/src/native-app/electrical-profile.ts
@@ -1,0 +1,31 @@
+import type { ElectricalProjectProfile } from '../types.js'
+
+export const DEFAULT_AREI_PROFILE: ElectricalProjectProfile = {
+  standard: 'AREI',
+  edition: 'Book 1 (current edition)',
+  supplyVoltageV: 230,
+  phaseConfiguration: 'single-phase',
+  earthingSystem: 'unknown',
+  defaultPoles: 2
+}
+
+export const normalizeElectricalProfile = (
+  profile: ElectricalProjectProfile | undefined
+): ElectricalProjectProfile => ({
+  standard: 'AREI',
+  edition: profile?.edition?.trim() || DEFAULT_AREI_PROFILE.edition,
+  supplyVoltageV:
+    typeof profile?.supplyVoltageV === 'number' && profile.supplyVoltageV > 0
+      ? profile.supplyVoltageV
+      : DEFAULT_AREI_PROFILE.supplyVoltageV,
+  phaseConfiguration:
+    profile?.phaseConfiguration === 'three-phase' ? 'three-phase' : 'single-phase',
+  earthingSystem:
+    profile?.earthingSystem === 'TT' || profile?.earthingSystem === 'TN' || profile?.earthingSystem === 'IT'
+      ? profile.earthingSystem
+      : 'unknown',
+  defaultPoles:
+    typeof profile?.defaultPoles === 'number' && profile.defaultPoles > 0
+      ? profile.defaultPoles
+      : DEFAULT_AREI_PROFILE.defaultPoles
+})

--- a/src/native-app/electrical-profile.ts
+++ b/src/native-app/electrical-profile.ts
@@ -3,6 +3,8 @@ import type { ElectricalProjectProfile } from '../types.js'
 export const DEFAULT_AREI_PROFILE: ElectricalProjectProfile = {
   standard: 'AREI',
   edition: 'Book 1 (current edition)',
+  distributor: '',
+  supplyConfiguration: '1x230V+N',
   supplyVoltageV: 230,
   phaseConfiguration: 'single-phase',
   earthingSystem: 'unknown',
@@ -14,6 +16,13 @@ export const normalizeElectricalProfile = (
 ): ElectricalProjectProfile => ({
   standard: 'AREI',
   edition: profile?.edition?.trim() || DEFAULT_AREI_PROFILE.edition,
+  distributor: profile?.distributor?.trim() || '',
+  supplyConfiguration:
+    profile?.supplyConfiguration === '3x230V' ||
+    profile?.supplyConfiguration === '3x400V+N' ||
+    profile?.supplyConfiguration === 'other'
+      ? profile.supplyConfiguration
+      : '1x230V+N',
   supplyVoltageV:
     typeof profile?.supplyVoltageV === 'number' && profile.supplyVoltageV > 0
       ? profile.supplyVoltageV

--- a/src/native-app/electrical-profile.ts
+++ b/src/native-app/electrical-profile.ts
@@ -8,7 +8,12 @@ export const DEFAULT_AREI_PROFILE: ElectricalProjectProfile = {
   supplyVoltageV: 230,
   phaseConfiguration: 'single-phase',
   earthingSystem: 'unknown',
-  defaultPoles: 2
+  defaultPoles: 2,
+  boards: [{
+    id: 'main',
+    name: 'Main distribution board',
+    rails: [{ id: 'rail-1', name: 'Rail 1' }]
+  }]
 }
 
 export const normalizeElectricalProfile = (
@@ -36,5 +41,13 @@ export const normalizeElectricalProfile = (
   defaultPoles:
     typeof profile?.defaultPoles === 'number' && profile.defaultPoles > 0
       ? profile.defaultPoles
-      : DEFAULT_AREI_PROFILE.defaultPoles
+      : DEFAULT_AREI_PROFILE.defaultPoles,
+  boards: profile?.boards?.length
+    ? profile.boards.map((board) => ({
+        ...board,
+        rails: board.rails?.length ? board.rails.map((rail) => ({ ...rail })) : [{ id: 'rail-1', name: 'Rail 1' }],
+        mainDifferential: board.mainDifferential ? { ...board.mainDifferential } : undefined,
+        additionalDifferentials: board.additionalDifferentials?.map((item) => ({ ...item }))
+      }))
+    : DEFAULT_AREI_PROFILE.boards?.map((board) => ({ ...board, rails: board.rails.map((rail) => ({ ...rail })) }))
 })

--- a/src/native-app/interaction/selection-payload.ts
+++ b/src/native-app/interaction/selection-payload.ts
@@ -2,6 +2,7 @@ import type { Shape } from '../../native-draw/types.js'
 import { shapeBounds } from '../../native-draw/model.js'
 import { listEditableSymbolTextFields } from '../symbol-svg-cache.js'
 import { electricalMetadataFromCatalog, type ElectricalDeviceMetadata } from '../../native-draw/electrical.js'
+import { circuitDefaults } from '../circuit-defaults.js'
 
 export type NativeSelectionSymbolTextField = {
   key: string
@@ -96,16 +97,16 @@ export const createNativeSelectionChangedPayload = (
     shapePayload.path = selectedShape.path
     const sourceElectrical = options?.electricalOverride ?? selectedShape.electrical ?? electricalMetadataFromCatalog(undefined, selectedShape.name, selectedShape.path)
     if (sourceElectrical.oneWireEligible || selectedShape.bindingId) {
-      const socketOrMotor = sourceElectrical.circuitType === 'sockets' || sourceElectrical.circuitType === 'motor' || sourceElectrical.circuitType === 'mixed'
+      const defaults = circuitDefaults(sourceElectrical.circuitType)
       shapePayload.electrical = {
         ...sourceElectrical,
-        breakerCurrentA: sourceElectrical.breakerCurrentA ?? (socketOrMotor ? 20 : 16),
-        cableSectionMm2: sourceElectrical.cableSectionMm2 ?? (socketOrMotor ? 2.5 : 1.5),
-        poles: sourceElectrical.poles ?? 2,
-        phaseConfiguration: sourceElectrical.phaseConfiguration ?? 'single-phase',
-        breakerCurve: sourceElectrical.breakerCurve ?? 'C',
-        boardId: sourceElectrical.boardId ?? 'main',
-        railId: sourceElectrical.railId ?? 'rail-1'
+        breakerCurrentA: sourceElectrical.breakerCurrentA ?? defaults.breakerCurrentA,
+        cableSectionMm2: sourceElectrical.cableSectionMm2 ?? defaults.cableSectionMm2,
+        poles: sourceElectrical.poles ?? defaults.poles,
+        phaseConfiguration: sourceElectrical.phaseConfiguration ?? defaults.phaseConfiguration,
+        breakerCurve: sourceElectrical.breakerCurve ?? defaults.breakerCurve,
+        boardId: sourceElectrical.boardId ?? defaults.boardId,
+        railId: sourceElectrical.railId ?? defaults.railId
       }
     }
     const isProtectionSymbol = /automaat|breaker|protection devices/i.test(`${selectedShape.name} ${selectedShape.path}`)

--- a/src/native-app/interaction/selection-payload.ts
+++ b/src/native-app/interaction/selection-payload.ts
@@ -1,7 +1,7 @@
 import type { Shape } from '../../native-draw/types.js'
 import { shapeBounds } from '../../native-draw/model.js'
 import { listEditableSymbolTextFields } from '../symbol-svg-cache.js'
-import type { ElectricalDeviceMetadata } from '../../native-draw/electrical.js'
+import { electricalMetadataFromCatalog, type ElectricalDeviceMetadata } from '../../native-draw/electrical.js'
 
 export type NativeSelectionSymbolTextField = {
   key: string
@@ -71,6 +71,8 @@ export const createNativeSelectionChangedPayload = (
   options?: {
     kindOverride?: string
     bindingIdOverride?: string
+    electricalOverride?: ElectricalDeviceMetadata
+    hideSymbolTextFields?: boolean
   }
 ): NativeSelectionChangedPayload => {
   const selectionCount = selectedIdsCount > 0 ? selectedIdsCount : selectedShape ? 1 : 0
@@ -92,8 +94,22 @@ export const createNativeSelectionChangedPayload = (
   if (selectedShape.kind === 'text') shapePayload.text = selectedShape.text
   if (selectedShape.kind === 'symbol') {
     shapePayload.path = selectedShape.path
-    if (selectedShape.electrical) shapePayload.electrical = { ...selectedShape.electrical }
-    const editableFields = listEditableSymbolTextFields(selectedShape.path)
+    const sourceElectrical = options?.electricalOverride ?? selectedShape.electrical ?? electricalMetadataFromCatalog(undefined, selectedShape.name, selectedShape.path)
+    if (sourceElectrical.oneWireEligible || selectedShape.bindingId) {
+      const socketOrMotor = sourceElectrical.circuitType === 'sockets' || sourceElectrical.circuitType === 'motor' || sourceElectrical.circuitType === 'mixed'
+      shapePayload.electrical = {
+        ...sourceElectrical,
+        breakerCurrentA: sourceElectrical.breakerCurrentA ?? (socketOrMotor ? 20 : 16),
+        cableSectionMm2: sourceElectrical.cableSectionMm2 ?? (socketOrMotor ? 2.5 : 1.5),
+        poles: sourceElectrical.poles ?? 2,
+        phaseConfiguration: sourceElectrical.phaseConfiguration ?? 'single-phase',
+        breakerCurve: sourceElectrical.breakerCurve ?? 'C',
+        boardId: sourceElectrical.boardId ?? 'main',
+        railId: sourceElectrical.railId ?? 'rail-1'
+      }
+    }
+    const isProtectionSymbol = /automaat|breaker|protection devices/i.test(`${selectedShape.name} ${selectedShape.path}`)
+    const editableFields = options?.hideSymbolTextFields || isProtectionSymbol ? [] : listEditableSymbolTextFields(selectedShape.path)
     if (editableFields.length) {
       const overrides = selectedShape.symbolTextOverrides ?? {}
       shapePayload.symbolTextFields = editableFields.map((field) => ({

--- a/src/native-app/interaction/selection-payload.ts
+++ b/src/native-app/interaction/selection-payload.ts
@@ -1,6 +1,7 @@
 import type { Shape } from '../../native-draw/types.js'
 import { shapeBounds } from '../../native-draw/model.js'
 import { listEditableSymbolTextFields } from '../symbol-svg-cache.js'
+import type { ElectricalDeviceMetadata } from '../../native-draw/electrical.js'
 
 export type NativeSelectionSymbolTextField = {
   key: string
@@ -14,6 +15,7 @@ export type NativeSelectionShapePayload = {
   text?: string
   path?: string
   symbolTextFields?: NativeSelectionSymbolTextField[]
+  electrical?: ElectricalDeviceMetadata
   bindingId?: string
   bindingLabelOffset?: { x: number; y: number }
   name?: string
@@ -90,6 +92,7 @@ export const createNativeSelectionChangedPayload = (
   if (selectedShape.kind === 'text') shapePayload.text = selectedShape.text
   if (selectedShape.kind === 'symbol') {
     shapePayload.path = selectedShape.path
+    if (selectedShape.electrical) shapePayload.electrical = { ...selectedShape.electrical }
     const editableFields = listEditableSymbolTextFields(selectedShape.path)
     if (editableFields.length) {
       const overrides = selectedShape.symbolTextOverrides ?? {}

--- a/src/native-app/interaction/selection-properties.ts
+++ b/src/native-app/interaction/selection-properties.ts
@@ -2,6 +2,7 @@ import { cloneShape, shapeBounds } from '../../native-draw/model.js'
 import type { Point, Shape } from '../../native-draw/types.js'
 import { bindingLabelOffset, type BindingLabelSide } from '../layout/symbol-layout.js'
 import { translateShape } from './shape-transforms.js'
+import type { ElectricalDeviceMetadata } from '../../native-draw/electrical.js'
 
 export type SelectionPropertyUpdate = {
   text?: string
@@ -19,6 +20,7 @@ export type SelectionPropertyUpdate = {
   letterSpacing?: number
   x?: number
   y?: number
+  electrical?: Partial<{ [K in keyof ElectricalDeviceMetadata]: ElectricalDeviceMetadata[K] | null }>
 }
 
 export type SelectionUpdateContext = {
@@ -154,6 +156,15 @@ const applyProperties = (
       .map(([key, value]) => [key.trim(), value] as const)
     if (entries.length) updated.symbolTextOverrides = Object.fromEntries(entries)
     else delete updated.symbolTextOverrides
+  }
+
+  if (payload.electrical && updated.kind === 'symbol') {
+    const electrical = { ...(updated.electrical ?? { role: 'neutral' as const, oneWireEligible: true }) }
+    for (const [key, value] of Object.entries(payload.electrical)) {
+      if (value === null || value === undefined) delete (electrical as Record<string, unknown>)[key]
+      else (electrical as Record<string, unknown>)[key] = value
+    }
+    updated.electrical = electrical
   }
 
   if (typeof payload.x !== 'number' && typeof payload.y !== 'number') return updated

--- a/src/native-app/intro-page.ts
+++ b/src/native-app/intro-page.ts
@@ -60,6 +60,8 @@ export const buildIntroPageSvg = (project: Project | null): string => {
   const btw = val(project?.installer?.btw)
   const eanCode = val(project?.eanCode)
   const mainFuseA = typeof project?.mainFuseA === 'number' ? `${project.mainFuseA} A` : '—'
+  const distributor = val(project?.electricalProfile?.distributor)
+  const supplyConfiguration = val(project?.electricalProfile?.supplyConfiguration)
 
   const street = val(project?.address?.street)
   const num = e(project?.address?.number?.trim() ?? '')
@@ -112,6 +114,8 @@ export const buildIntroPageSvg = (project: Project | null): string => {
   ${fieldRow(13, S2_Y + 39, 'BTW / KBO', btw)}
   ${inputBox(COL + 3, S2_Y + 9, 88, 13, 'EAN-CODE (18 CIJFERS)', eanCode)}
   ${inputBox(COL + 3, S2_Y + 30, 42, 13, 'HOOFDZEKERING', mainFuseA)}
+  ${inputBox(COL + 49, S2_Y + 30, 42, 13, 'NETBEHEERDER', distributor)}
+  ${inputBox(COL + 3, S2_Y + 46, 88, 13, 'NETAANSLUITING', supplyConfiguration)}
   ${vline(COL, S2_Y, S2_Y + S2_H)}
   ${hline(S2_Y + S2_H)}
 

--- a/src/native-app/layout/onewire-builder.ts
+++ b/src/native-app/layout/onewire-builder.ts
@@ -23,6 +23,7 @@ const createSymbol = (
   position: Point,
   name: string,
   path: string,
+  bindingId: string,
   groupId: string,
   kind: 'breaker' | 'switch' | 'load'
 ): SymbolShape => ({
@@ -31,6 +32,7 @@ const createSymbol = (
   position,
   name,
   path,
+  bindingId,
   scale:
     kind === 'breaker'
       ? Math.max(0.4, inferSymbolScale(path))
@@ -53,12 +55,21 @@ const createBreakerSymbol = (
   center: Point,
   _boxW: number,
   _boxH: number,
+  bindingId: string,
   groupId: string
-): SymbolShape[] => [createSymbol(nextId(), center, 'Automaat', RESIDENTIAL_BREAKER_SYMBOL_PATH, groupId, 'breaker')]
+): SymbolShape[] => [
+  createSymbol(nextId(), center, 'Automaat', RESIDENTIAL_BREAKER_SYMBOL_PATH, bindingId, groupId, 'breaker')
+]
 
 // Use existing residential symbol for switch
-const createSwitchSymbol = (nextId: () => string, center: Point, _size: number, groupId: string): SymbolShape[] => [
-  createSymbol(nextId(), center, 'Switch', RESIDENTIAL_SWITCH_SYMBOL_PATH, groupId, 'switch')
+const createSwitchSymbol = (
+  nextId: () => string,
+  center: Point,
+  _size: number,
+  bindingId: string,
+  groupId: string
+): SymbolShape[] => [
+  createSymbol(nextId(), center, 'Switch', RESIDENTIAL_SWITCH_SYMBOL_PATH, bindingId, groupId, 'switch')
 ]
 
 // Use preset-specific residential symbol for load
@@ -67,8 +78,11 @@ const createLoadSymbol = (
   center: Point,
   _size: number,
   preset: OneWirePresetConfig,
+  bindingId: string,
   groupId: string
-): SymbolShape[] => [createSymbol(nextId(), center, 'Load', loadSymbolPathForPreset(preset), groupId, 'load')]
+): SymbolShape[] => [
+  createSymbol(nextId(), center, 'Load', loadSymbolPathForPreset(preset), bindingId, groupId, 'load')
+]
 
 // Vertical gap between components inside a circuit column.
 const COMPONENT_GAP = 44
@@ -110,9 +124,9 @@ export const buildOneWireCircuit = (
   // Labels sit to the right of each component
   const labelX = x + nodeSize / 2 + 8
 
-  const breakerShapes = createBreakerSymbol(nextId, breakerCenter, nodeSize, breakerWidth, groupId)
-  const switchShapes = createSwitchSymbol(nextId, switchCenter, nodeSize, groupId)
-  const loadShapes = createLoadSymbol(nextId, loadCenter, nodeSize, preset, groupId)
+  const breakerShapes = createBreakerSymbol(nextId, breakerCenter, nodeSize, breakerWidth, bindingId, groupId)
+  const switchShapes = createSwitchSymbol(nextId, switchCenter, nodeSize, bindingId, groupId)
+  const loadShapes = createLoadSymbol(nextId, loadCenter, nodeSize, preset, bindingId, groupId)
 
   const shapes: Shape[] = [
     // Binding-ID label to the left of the busbar connection point

--- a/src/native-app/layout/onewire-helpers.ts
+++ b/src/native-app/layout/onewire-helpers.ts
@@ -17,10 +17,17 @@ type OneWireCatalogComponent = {
   sourceShapeId?: string
   sourcePath?: string
   sourceName?: string
+  breakerCurrentA?: number
+  cableSectionMm2?: number
+  poles?: number
+  breakerCurve?: string
 }
 
 type OneWireBundleOptions = {
   amps: number
+  poles?: number
+  phaseConfiguration?: 'single-phase' | 'three-phase'
+  breakerCurve?: string
   family: string
   autoIncludeFamily: boolean
 }
@@ -31,6 +38,10 @@ type OneWireResolvedComponent = {
   sourcePath?: string
   sourceName?: string
   sourceShapeId?: string
+  breakerCurrentA?: number
+  cableSectionMm2?: number
+  poles?: number
+  breakerCurve?: string
 }
 
 type OneWireBuilderDeps = {
@@ -92,7 +103,8 @@ export const buildOneWireBreakerSection = (
   startX: number,
   bindingId: string,
   familyLabel: string,
-  deps: OneWireBuilderDeps
+  deps: OneWireBuilderDeps,
+  specification?: Pick<OneWireBundleOptions, 'amps' | 'poles' | 'phaseConfiguration'>
 ): { shapes: Shape[]; ids: string[]; breakerContentTopY: number } => {
   const x = snapToGrid(startX)
   const component = deps.oneWireComponentSymbol('breaker')
@@ -115,6 +127,11 @@ export const buildOneWireBreakerSection = (
     strokeWidth: 0.5,
     bindingId,
     groupId
+  }
+  symbol.symbolTextOverrides = {
+    'desc:nP': `${specification?.poles ?? 2}P`,
+    'desc:n': specification?.phaseConfiguration === 'three-phase' ? '3N' : '1N',
+    'desc:20A': `${specification?.amps ?? 20}A`
   }
 
   const connector: LineShape = {
@@ -361,6 +378,20 @@ export const buildOneWireRowSection = (
   shapes.push(rowNumberLabel)
   ids.push(rowNumberLabel.id)
 
+  const specification = entries[0]
+  if (specification?.breakerCurrentA || specification?.cableSectionMm2) {
+    const curve = specification.breakerCurve ?? 'C'
+    const specificationLabel: TextShape = {
+      id: deps.nextShapeId(), kind: 'text', position: { x: rowJunctionX - 25, y: rowY + 22 },
+      text: `${curve}${specification.breakerCurrentA ?? 16} · ${specification.poles ?? 2}P · ${specification.cableSectionMm2 ?? 1.5} mm²`,
+      fill: '#000000', scale: 0.55, bindingId, groupId: rowGroupId,
+      sourceLink: { kind: 'circuit', id: bindingId, role: 'specification-label' },
+      generationKey: `circuit:${bindingId}:specification-label`
+    }
+    shapes.push(specificationLabel)
+    ids.push(specificationLabel.id)
+  }
+
   if (lampCount > 1) {
     const countLabel: TextShape = {
       id: deps.nextShapeId(),
@@ -403,7 +434,7 @@ export const buildKamrailCircuitBundle = (
   const createdIds: string[] = []
   const shapes: Shape[] = []
 
-  const breaker = buildOneWireBreakerSection(railY, startX, options.family, options.family, deps)
+  const breaker = buildOneWireBreakerSection(railY, startX, options.family, options.family, deps, options)
   breaker.shapes.forEach((shape, index) => {
     shape.sourceLink = { kind: 'board', id: options.family, role: index === 1 ? 'breaker' : index === 0 ? 'feed' : 'label' }
     shape.generationKey = `board:${options.family}:${shape.sourceLink.role}`

--- a/src/native-app/layout/onewire-helpers.ts
+++ b/src/native-app/layout/onewire-helpers.ts
@@ -14,6 +14,7 @@ type OneWireComponentKind = 'breaker' | 'switch' | 'kamrail' | 'load'
 type OneWireCatalogComponent = {
   bindingId: string
   kind: 'switch' | 'load'
+  sourceShapeId?: string
   sourcePath?: string
   sourceName?: string
 }
@@ -29,6 +30,7 @@ type OneWireResolvedComponent = {
   kind: 'switch' | 'load'
   sourcePath?: string
   sourceName?: string
+  sourceShapeId?: string
 }
 
 type OneWireBuilderDeps = {
@@ -268,6 +270,13 @@ export const buildOneWireRowSection = (
       bindingId,
       groupId: rowGroupId
     }
+    const source = orderedEntries[symbolIndex]
+    symbol.sourceLink = {
+      kind: source?.sourceShapeId ? 'device' : 'circuit',
+      id: source?.sourceShapeId ?? bindingId,
+      role: spec.kind
+    }
+    symbol.generationKey = `device:${source?.sourceShapeId ?? `${bindingId}:${spec.kind}:${symbolIndex}`}`
     if (typeof spec.rotation === 'number') symbol.rotation = spec.rotation
     return symbol
   })
@@ -347,6 +356,8 @@ export const buildOneWireRowSection = (
     bindingId,
     groupId: rowGroupId
   }
+  rowNumberLabel.sourceLink = { kind: 'circuit', id: bindingId, role: 'number-label' }
+  rowNumberLabel.generationKey = `circuit:${bindingId}:number-label`
   shapes.push(rowNumberLabel)
   ids.push(rowNumberLabel.id)
 
@@ -393,6 +404,10 @@ export const buildKamrailCircuitBundle = (
   const shapes: Shape[] = []
 
   const breaker = buildOneWireBreakerSection(railY, startX, options.family, options.family, deps)
+  breaker.shapes.forEach((shape, index) => {
+    shape.sourceLink = { kind: 'board', id: options.family, role: index === 1 ? 'breaker' : index === 0 ? 'feed' : 'label' }
+    shape.generationKey = `board:${options.family}:${shape.sourceLink.role}`
+  })
   shapes.push(...breaker.shapes)
   createdIds.push(...breaker.ids)
 
@@ -410,6 +425,8 @@ export const buildKamrailCircuitBundle = (
       bindingId: options.family,
       groupId: `onewire-${deps.nextShapeId()}`
     }
+    trunk.sourceLink = { kind: 'board', id: options.family, role: 'trunk' }
+    trunk.generationKey = `board:${options.family}:trunk`
     shapes.push(trunk)
     createdIds.push(trunk.id)
   }

--- a/src/native-app/layout/onewire-layout-plan.ts
+++ b/src/native-app/layout/onewire-layout-plan.ts
@@ -1,0 +1,44 @@
+export type OneWireFamilyDemand = { family: string; circuitCount: number }
+export type OneWireFamilyPlacement = { family: string; pageIndex: number; railIndex: number; slotIndex: number }
+
+export type OneWireLayoutPlan = {
+  placements: OneWireFamilyPlacement[]
+  pageCount: number
+  railsPerPage: number
+  slotsPerRail: number
+}
+
+export const planOneWireLayout = (
+  families: readonly OneWireFamilyDemand[],
+  options: { usableWidth: number; usableHeight: number; minBranchWidth?: number; railHeight?: number }
+): OneWireLayoutPlan => {
+  const minBranchWidth = Math.max(120, options.minBranchWidth ?? 220)
+  const railHeight = Math.max(220, options.railHeight ?? 320)
+  const slotsPerRail = Math.max(1, Math.floor(options.usableWidth / minBranchWidth))
+  const railsPerPage = Math.max(1, Math.floor(options.usableHeight / railHeight))
+  const placements: OneWireFamilyPlacement[] = []
+  let absoluteRail = 0
+  let slotIndex = 0
+
+  for (const demand of families) {
+    const requiredWidthSlots = Math.max(1, Math.ceil(demand.circuitCount / 4))
+    if (slotIndex > 0 && slotIndex + requiredWidthSlots > slotsPerRail) {
+      absoluteRail += 1
+      slotIndex = 0
+    }
+    placements.push({
+      family: demand.family,
+      pageIndex: Math.floor(absoluteRail / railsPerPage),
+      railIndex: absoluteRail % railsPerPage,
+      slotIndex
+    })
+    slotIndex += requiredWidthSlots
+    if (slotIndex >= slotsPerRail) {
+      absoluteRail += 1
+      slotIndex = 0
+    }
+  }
+
+  const pageCount = placements.length ? Math.max(...placements.map((placement) => placement.pageIndex)) + 1 : 0
+  return { placements, pageCount, railsPerPage, slotsPerRail }
+}

--- a/src/native-app/layout/onewire-regeneration.ts
+++ b/src/native-app/layout/onewire-regeneration.ts
@@ -1,0 +1,45 @@
+import type { Shape } from '../../native-draw/types.js'
+
+const preserveManualGeometry = (fresh: Shape, previous: Shape): Shape => {
+  if (fresh.kind !== previous.kind) return fresh
+  if ('position' in fresh && 'position' in previous) {
+    const preserved = { ...fresh, position: { ...previous.position }, rotation: previous.rotation } as Shape
+    if ('scale' in preserved && 'scale' in previous) preserved.scale = previous.scale
+    return preserved
+  }
+  if ('start' in fresh && 'start' in previous && 'end' in fresh && 'end' in previous) {
+    return { ...fresh, start: { ...previous.start }, end: { ...previous.end } } as Shape
+  }
+  return fresh
+}
+
+export type OneWireRegenerationResult = {
+  shapes: Shape[]
+  preserved: number
+  added: number
+  removed: number
+}
+
+export const reconcileGeneratedOneWire = (
+  previous: readonly Shape[],
+  fresh: readonly Shape[]
+): OneWireRegenerationResult => {
+  const previousByKey = new Map(
+    previous.filter((shape) => shape.generationKey).map((shape) => [shape.generationKey as string, shape])
+  )
+  let preserved = 0
+  const shapes = fresh.map((shape) => {
+    if (!shape.generationKey) return shape
+    const matching = previousByKey.get(shape.generationKey)
+    if (!matching) return shape
+    preserved += 1
+    return preserveManualGeometry(shape, matching)
+  })
+  const freshKeys = new Set(fresh.map((shape) => shape.generationKey).filter(Boolean))
+  return {
+    shapes,
+    preserved,
+    added: fresh.filter((shape) => !shape.generationKey || !previousByKey.has(shape.generationKey)).length,
+    removed: previous.filter((shape) => shape.generationKey && !freshKeys.has(shape.generationKey)).length
+  }
+}

--- a/src/native-app/layout/onewire-regeneration.ts
+++ b/src/native-app/layout/onewire-regeneration.ts
@@ -3,12 +3,12 @@ import type { Shape } from '../../native-draw/types.js'
 const preserveManualGeometry = (fresh: Shape, previous: Shape): Shape => {
   if (fresh.kind !== previous.kind) return fresh
   if ('position' in fresh && 'position' in previous) {
-    const preserved = { ...fresh, position: { ...previous.position }, rotation: previous.rotation } as Shape
+    const preserved = { ...fresh, id: previous.id, position: { ...previous.position }, rotation: previous.rotation } as Shape
     if ('scale' in preserved && 'scale' in previous) preserved.scale = previous.scale
     return preserved
   }
   if ('start' in fresh && 'start' in previous && 'end' in fresh && 'end' in previous) {
-    return { ...fresh, start: { ...previous.start }, end: { ...previous.end } } as Shape
+    return { ...fresh, id: previous.id, start: { ...previous.start }, end: { ...previous.end } } as Shape
   }
   return fresh
 }

--- a/src/native-draw/electrical.ts
+++ b/src/native-draw/electrical.ts
@@ -11,6 +11,12 @@ export type ElectricalDeviceMetadata = {
   poles?: number
   phaseConfiguration?: ElectricalPhaseConfiguration
   cableSectionMm2?: number
+  breakerCurve?: 'B' | 'C' | 'D' | 'other'
+  rcdSensitivityMa?: number
+  rcdType?: 'AC' | 'A' | 'F' | 'B' | 'other'
+  boardId?: string
+  railId?: string
+  notes?: string
 }
 
 const finitePositive = (value: unknown): number | undefined =>
@@ -73,7 +79,19 @@ export const electricalMetadataFromCatalog = (
     breakerCurrentA: finitePositive(explicit.breakerCurrentA),
     poles: finitePositive(explicit.poles),
     phaseConfiguration,
-    cableSectionMm2: finitePositive(explicit.cableSectionMm2)
+    cableSectionMm2: finitePositive(explicit.cableSectionMm2),
+    breakerCurve:
+      explicit.breakerCurve === 'B' || explicit.breakerCurve === 'C' || explicit.breakerCurve === 'D' || explicit.breakerCurve === 'other'
+        ? explicit.breakerCurve
+        : undefined,
+    rcdSensitivityMa: finitePositive(explicit.rcdSensitivityMa),
+    rcdType:
+      explicit.rcdType === 'AC' || explicit.rcdType === 'A' || explicit.rcdType === 'F' || explicit.rcdType === 'B' || explicit.rcdType === 'other'
+        ? explicit.rcdType
+        : undefined,
+    boardId: typeof explicit.boardId === 'string' ? explicit.boardId.trim() || undefined : undefined,
+    railId: typeof explicit.railId === 'string' ? explicit.railId.trim() || undefined : undefined,
+    notes: typeof explicit.notes === 'string' ? explicit.notes.trim() || undefined : undefined
   }
 }
 
@@ -103,6 +121,12 @@ export const sanitizeElectricalMetadata = (value: unknown): ElectricalDeviceMeta
       raw.phaseConfiguration === 'single-phase' || raw.phaseConfiguration === 'three-phase'
         ? raw.phaseConfiguration
         : undefined,
-    cableSectionMm2: finitePositive(raw.cableSectionMm2)
+    cableSectionMm2: finitePositive(raw.cableSectionMm2),
+    breakerCurve: raw.breakerCurve === 'B' || raw.breakerCurve === 'C' || raw.breakerCurve === 'D' || raw.breakerCurve === 'other' ? raw.breakerCurve : undefined,
+    rcdSensitivityMa: finitePositive(raw.rcdSensitivityMa),
+    rcdType: raw.rcdType === 'AC' || raw.rcdType === 'A' || raw.rcdType === 'F' || raw.rcdType === 'B' || raw.rcdType === 'other' ? raw.rcdType : undefined,
+    boardId: typeof raw.boardId === 'string' ? raw.boardId.trim() || undefined : undefined,
+    railId: typeof raw.railId === 'string' ? raw.railId.trim() || undefined : undefined,
+    notes: typeof raw.notes === 'string' ? raw.notes.trim() || undefined : undefined
   }
 }

--- a/src/native-draw/model.ts
+++ b/src/native-draw/model.ts
@@ -33,6 +33,24 @@ export const isPoint = (value: unknown): value is Point => {
   )
 }
 
+const copyGeneratedMetadata = (
+  source: { generationKey?: unknown; sourceLink?: unknown },
+  target: Shape
+): void => {
+  if (typeof source.generationKey === 'string' && source.generationKey.trim()) {
+    target.generationKey = source.generationKey.trim()
+  }
+  if (source.sourceLink && typeof source.sourceLink === 'object') {
+    const link = source.sourceLink as { kind?: unknown; id?: unknown; role?: unknown }
+    if (
+      (link.kind === 'board' || link.kind === 'circuit' || link.kind === 'device') &&
+      typeof link.id === 'string' && link.id.trim() && typeof link.role === 'string' && link.role.trim()
+    ) {
+      target.sourceLink = { kind: link.kind, id: link.id.trim(), role: link.role.trim() }
+    }
+  }
+}
+
 export const sanitizeShapes = (values: unknown[]): Shape[] => {
   const shapes: Shape[] = []
   for (const value of values) {
@@ -63,6 +81,8 @@ export const sanitizeShapes = (values: unknown[]): Shape[] => {
       groupId?: unknown
       bindingLabelOffset?: unknown
       catalogShapes?: unknown
+      generationKey?: unknown
+      sourceLink?: unknown
     }
     if (typeof raw.id !== 'string' || !raw.id) continue
     if (typeof raw.kind !== 'string') continue
@@ -95,6 +115,7 @@ export const sanitizeShapes = (values: unknown[]): Shape[] => {
       if (typeof raw.bindingId === 'string' && raw.bindingId.trim()) line.bindingId = raw.bindingId.trim().toUpperCase()
       if (typeof raw.groupId === 'string' && raw.groupId.trim()) line.groupId = raw.groupId.trim()
       if (isPoint(raw.bindingLabelOffset)) line.bindingLabelOffset = clonePoint(raw.bindingLabelOffset)
+      copyGeneratedMetadata(raw, line)
       shapes.push(line)
       continue
     }
@@ -121,6 +142,7 @@ export const sanitizeShapes = (values: unknown[]): Shape[] => {
       if (typeof raw.bindingId === 'string' && raw.bindingId.trim()) rect.bindingId = raw.bindingId.trim().toUpperCase()
       if (typeof raw.groupId === 'string' && raw.groupId.trim()) rect.groupId = raw.groupId.trim()
       if (isPoint(raw.bindingLabelOffset)) rect.bindingLabelOffset = clonePoint(raw.bindingLabelOffset)
+      copyGeneratedMetadata(raw, rect)
       shapes.push(rect)
       continue
     }
@@ -146,6 +168,7 @@ export const sanitizeShapes = (values: unknown[]): Shape[] => {
       if (typeof raw.bindingId === 'string' && raw.bindingId.trim()) text.bindingId = raw.bindingId.trim().toUpperCase()
       if (typeof raw.groupId === 'string' && raw.groupId.trim()) text.groupId = raw.groupId.trim()
       if (isPoint(raw.bindingLabelOffset)) text.bindingLabelOffset = clonePoint(raw.bindingLabelOffset)
+      copyGeneratedMetadata(raw, text)
       shapes.push(text)
       continue
     }
@@ -191,6 +214,7 @@ export const sanitizeShapes = (values: unknown[]): Shape[] => {
       if (Array.isArray(raw.catalogShapes)) {
         symbol.catalogShapes = sanitizeShapes(raw.catalogShapes)
       }
+      copyGeneratedMetadata(raw, symbol)
       shapes.push(symbol)
       continue
     }
@@ -226,6 +250,7 @@ export const sanitizeShapes = (values: unknown[]): Shape[] => {
         image.bindingId = raw.bindingId.trim().toUpperCase()
       if (typeof raw.groupId === 'string' && raw.groupId.trim()) image.groupId = raw.groupId.trim()
       if (isPoint(raw.bindingLabelOffset)) image.bindingLabelOffset = clonePoint(raw.bindingLabelOffset)
+      copyGeneratedMetadata(raw, image)
       shapes.push(image)
     }
   }
@@ -256,6 +281,7 @@ export const cloneShape = (shape: Shape): Shape => {
       if (shape.bindingId) cloned.bindingId = shape.bindingId
       if (shape.groupId) cloned.groupId = shape.groupId
       if (shape.bindingLabelOffset) cloned.bindingLabelOffset = { ...shape.bindingLabelOffset }
+      copyGeneratedMetadata(shape, cloned)
       return cloned
     }
     case 'rect': {
@@ -276,6 +302,7 @@ export const cloneShape = (shape: Shape): Shape => {
       if (shape.bindingId) rect.bindingId = shape.bindingId
       if (shape.groupId) rect.groupId = shape.groupId
       if (shape.bindingLabelOffset) rect.bindingLabelOffset = { ...shape.bindingLabelOffset }
+      copyGeneratedMetadata(shape, rect)
       return rect
     }
     case 'text': {
@@ -295,6 +322,7 @@ export const cloneShape = (shape: Shape): Shape => {
       if (shape.bindingId) text.bindingId = shape.bindingId
       if (shape.groupId) text.groupId = shape.groupId
       if (shape.bindingLabelOffset) text.bindingLabelOffset = { ...shape.bindingLabelOffset }
+      copyGeneratedMetadata(shape, text)
       return text
     }
     case 'symbol': {
@@ -317,6 +345,7 @@ export const cloneShape = (shape: Shape): Shape => {
       if (shape.bindingId) symbol.bindingId = shape.bindingId
       if (shape.groupId) symbol.groupId = shape.groupId
       if (shape.bindingLabelOffset) symbol.bindingLabelOffset = { ...shape.bindingLabelOffset }
+      copyGeneratedMetadata(shape, symbol)
       return symbol
     }
     case 'image': {
@@ -338,6 +367,7 @@ export const cloneShape = (shape: Shape): Shape => {
       if (shape.bindingId) image.bindingId = shape.bindingId
       if (shape.groupId) image.groupId = shape.groupId
       if (shape.bindingLabelOffset) image.bindingLabelOffset = { ...shape.bindingLabelOffset }
+      copyGeneratedMetadata(shape, image)
       return image
     }
   }
@@ -368,6 +398,7 @@ export const scaleShape = (shape: Shape, scaleX: number, scaleY: number): Shape 
       if (typeof shape.strokeWidth === 'number') scaled.strokeWidth = shape.strokeWidth
       if (shape.bindingId) scaled.bindingId = shape.bindingId
       if (shape.groupId) scaled.groupId = shape.groupId
+      copyGeneratedMetadata(shape, scaled)
       return scaled
     }
     case 'rect': {
@@ -387,6 +418,7 @@ export const scaleShape = (shape: Shape, scaleX: number, scaleY: number): Shape 
       if (typeof shape.strokeWidth === 'number') rect.strokeWidth = shape.strokeWidth
       if (shape.bindingId) rect.bindingId = shape.bindingId
       if (shape.groupId) rect.groupId = shape.groupId
+      copyGeneratedMetadata(shape, rect)
       return rect
     }
     case 'text': {
@@ -405,6 +437,7 @@ export const scaleShape = (shape: Shape, scaleX: number, scaleY: number): Shape 
       if (shape.flipY) text.flipY = true
       if (shape.bindingId) text.bindingId = shape.bindingId
       if (shape.groupId) text.groupId = shape.groupId
+      copyGeneratedMetadata(shape, text)
       return text
     }
     case 'symbol': {
@@ -417,6 +450,8 @@ export const scaleShape = (shape: Shape, scaleX: number, scaleY: number): Shape 
         scale: shape.scale * (scaleX + scaleY) * 0.5
       }
       if (shape.symbolTextOverrides) symbol.symbolTextOverrides = { ...shape.symbolTextOverrides }
+      if (shape.electrical) symbol.electrical = { ...shape.electrical }
+      if (shape.catalogShapes) symbol.catalogShapes = cloneShapes(shape.catalogShapes)
       if (shape.rotation) symbol.rotation = shape.rotation
       if (shape.fill) symbol.fill = shape.fill
       if (shape.stroke) symbol.stroke = shape.stroke
@@ -425,6 +460,7 @@ export const scaleShape = (shape: Shape, scaleX: number, scaleY: number): Shape 
       if (shape.flipY) symbol.flipY = true
       if (shape.bindingId) symbol.bindingId = shape.bindingId
       if (shape.groupId) symbol.groupId = shape.groupId
+      copyGeneratedMetadata(shape, symbol)
       return symbol
     }
     case 'image': {
@@ -445,6 +481,7 @@ export const scaleShape = (shape: Shape, scaleX: number, scaleY: number): Shape 
       if (shape.flipY) image.flipY = true
       if (shape.bindingId) image.bindingId = shape.bindingId
       if (shape.groupId) image.groupId = shape.groupId
+      copyGeneratedMetadata(shape, image)
       return image
     }
   }

--- a/src/native-draw/types.ts
+++ b/src/native-draw/types.ts
@@ -14,7 +14,18 @@ export type Tool =
 
 export type Point = { x: number; y: number }
 
-export type LineShape = {
+export type OneWireSourceLink = {
+  kind: 'board' | 'circuit' | 'device'
+  id: string
+  role: string
+}
+
+type GeneratedShapeMetadata = {
+  generationKey?: string
+  sourceLink?: OneWireSourceLink
+}
+
+export type LineShape = GeneratedShapeMetadata & {
   id: string
   kind: 'wall' | 'line' | 'door' | 'window' | 'gate'
   start: Point
@@ -32,7 +43,7 @@ export type LineShape = {
   bindingLabelOffset?: { x: number; y: number }
 }
 
-export type RectShape = {
+export type RectShape = GeneratedShapeMetadata & {
   id: string
   kind: 'rect'
   start: Point
@@ -50,7 +61,7 @@ export type RectShape = {
   bindingLabelOffset?: { x: number; y: number }
 }
 
-export type TextShape = {
+export type TextShape = GeneratedShapeMetadata & {
   id: string
   kind: 'text'
   position: Point
@@ -69,7 +80,7 @@ export type TextShape = {
   bindingLabelOffset?: { x: number; y: number }
 }
 
-export type SymbolShape = {
+export type SymbolShape = GeneratedShapeMetadata & {
   id: string
   kind: 'symbol'
   position: Point
@@ -90,7 +101,7 @@ export type SymbolShape = {
   catalogShapes?: Shape[]
 }
 
-export type ImageShape = {
+export type ImageShape = GeneratedShapeMetadata & {
   id: string
   kind: 'image'
   position: Point

--- a/src/service-worker/cache-policy.ts
+++ b/src/service-worker/cache-policy.ts
@@ -1,0 +1,5 @@
+export const isCacheableSvgRequest = (request: Request, origin: string): boolean => {
+  if (request.method !== 'GET') return false
+  const url = new URL(request.url)
+  return url.origin === origin && url.pathname.toLowerCase().endsWith('.svg')
+}

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -49,6 +49,7 @@ import { type BomRow, type CircuitAnalysis } from './native-app/circuit-analysis
 import { ensureOneWirePage } from './shell/page-operations.js'
 import { clonePageSchema } from './shell/page-schema.js'
 import { downloadBom, downloadDataUrl } from './shell/export-commands.js'
+import { evaluateOneWirePreflight } from './shell/onewire-preflight.js'
 
 type A4Orientation = 'portrait' | 'landscape'
 type A4ExportResult = {
@@ -924,6 +925,18 @@ export class AppShell extends LiteElement {
       return
     }
     this.project = await getProjectData(this.projectKey)
+
+    const report = nativeApp?.analyzeBindings?.() ?? null
+    const preflight = evaluateOneWirePreflight(report)
+    if (preflight.ready === false) {
+      if (report) {
+        this.validationReportData = report
+        this.validationReportOpen = true
+      } else {
+        globalThis.alert(preflight.message)
+      }
+      return
+    }
 
     const oneWirePage = await ensureOneWirePage(this.projectKey, this.project)
     if (!oneWirePage) return

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -79,7 +79,7 @@ type NativeAppElement = HTMLElement & {
   exportA4PNG?: (orientation?: A4Orientation | 'auto') => Promise<A4ExportResult>
   analyzeBindings?: () => CircuitAnalysis
   getBOMRows?: () => BomRow[]
-  generateAutoOneWire?: () => { generated: boolean; circuitCount: number; message?: string }
+  generateAutoOneWire?: (pageIndex?: number) => { generated: boolean; circuitCount: number; pageCount?: number; message?: string }
   waitForPageReady?: (pageKey: string) => Promise<boolean>
   flushPendingSave?: () => Promise<void>
 }
@@ -948,8 +948,31 @@ export class AppShell extends LiteElement {
       globalThis.alert('The one-wire page did not finish loading. Please try again.')
       return
     }
-    const result = nativeApp?.generateAutoOneWire?.()
+    const result = nativeApp?.generateAutoOneWire?.(0)
     if (!result?.generated) globalThis.alert(result?.message ?? 'Unable to generate the one-wire diagram.')
+    if (!result?.generated || !result.pageCount || result.pageCount <= 1) return
+
+    await nativeApp.flushPendingSave?.()
+    for (let pageIndex = 1; pageIndex < result.pageCount; pageIndex += 1) {
+      const pageName = `One-wire diagram ${pageIndex + 1}`
+      let overflowPageKey = Object.entries(this.project.pages).find(
+        ([, page]) => page.pageType === 'onewire' && page.name === pageName
+      )?.[0]
+      if (!overflowPageKey) {
+        await addPage(this.projectKey, pageName, { version: 'native-svg-1', objects: [] }, 'onewire')
+        this.project = await getProjectData(this.projectKey)
+        overflowPageKey = Object.entries(this.project.pages).find(
+          ([, page]) => page.pageType === 'onewire' && page.name === pageName
+        )?.[0]
+      }
+      if (!overflowPageKey) continue
+      await this.loadPage(overflowPageKey)
+      await nativeApp.waitForPageReady?.(overflowPageKey)
+      nativeApp.generateAutoOneWire?.(pageIndex)
+      await nativeApp.flushPendingSave?.()
+    }
+    this.project = await getProjectData(this.projectKey)
+    await this.loadPage(oneWirePage.pageKey)
   }
 
   async validateBindingsForOneWire() {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -82,6 +82,7 @@ type NativeAppElement = HTMLElement & {
   generateAutoOneWire?: (pageIndex?: number) => { generated: boolean; circuitCount: number; pageCount?: number; message?: string }
   waitForPageReady?: (pageKey: string) => Promise<boolean>
   flushPendingSave?: () => Promise<void>
+  flushPendingCircuitUpdates?: () => Promise<void>
 }
 
 type ShellProjectStore = {
@@ -919,6 +920,7 @@ export class AppShell extends LiteElement {
 
     const nativeApp = this.shadowRoot?.querySelector('cadle-app') as NativeAppElement | null
     try {
+      await nativeApp?.flushPendingCircuitUpdates?.()
       await nativeApp?.flushPendingSave?.()
     } catch {
       globalThis.alert('The floor plan could not be saved. One-wire generation was cancelled to protect your work.')

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -527,6 +527,15 @@ export class AppShell extends LiteElement {
       this.projects = []
     }
 
+    // Resolve the initial screen before catalog loading so first-time users never
+    // spend that work looking at an editor without an open project.
+    this.#captureReloadResumeFromHash()
+    const initialRoute = parseHash(location.hash).route
+    if (!initialRoute || ((initialRoute === 'native-draw' || initialRoute === 'draw' || initialRoute === 'save') && !this.showReopenPreviousProjectPrompt)) {
+      location.hash = '#!/projects'
+    }
+    await this.#onhashchange()
+
     // for (const key of keys) {
     //   projects.push(typeof key === 'string' ? key : decoder.decode(key))
     // }
@@ -572,14 +581,12 @@ export class AppShell extends LiteElement {
     }
 
     onhashchange = this.#onhashchange.bind(this)
-    this.#captureReloadResumeFromHash()
     if (this.showReopenPreviousProjectPrompt) {
       pubsub.publish('shell.reopen-previous-project-prompt', {
         open: true,
         projectName: this.previousProjectName
       })
     }
-    this.#onhashchange()
     this.addEventListener('drop', this.#drop.bind(this))
     this.addEventListener('dragover', this.#dragover.bind(this))
     this.addEventListener('binding-lookup-updated', this.#onBindingLookupUpdated as EventListener)

--- a/src/shell/onewire-preflight.ts
+++ b/src/shell/onewire-preflight.ts
@@ -1,0 +1,36 @@
+export type OneWirePreflightReport = {
+  totalGroups: number
+  errorCount: number
+  valid: boolean
+}
+
+export type OneWirePreflightResult =
+  | { ready: true }
+  | { ready: false; reason: 'unavailable' | 'empty' | 'invalid'; message: string }
+
+export const evaluateOneWirePreflight = (
+  report: OneWirePreflightReport | null | undefined
+): OneWirePreflightResult => {
+  if (!report) {
+    return {
+      ready: false,
+      reason: 'unavailable',
+      message: 'The ground plan could not be analysed. Keep the ground-plan page open and try again.'
+    }
+  }
+  if (report.totalGroups === 0) {
+    return {
+      ready: false,
+      reason: 'empty',
+      message: 'Add electrical devices to the ground plan and assign circuit IDs such as A1 before generating.'
+    }
+  }
+  if (!report.valid || report.errorCount > 0) {
+    return {
+      ready: false,
+      reason: 'invalid',
+      message: 'Resolve the ground-plan validation errors before generating the one-wire diagram.'
+    }
+  }
+  return { ready: true }
+}

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,4 +1,6 @@
-const CACHE_NAME = 'cadle-symbol-assets-v1'
+import { isCacheableSvgRequest } from './service-worker/cache-policy.js'
+
+const CACHE_NAME = 'cadle-svg-assets-v2'
 
 type ExtendableEventLike = Event & {
   waitUntil(promise: Promise<unknown>): void
@@ -15,20 +17,6 @@ const serviceWorkerGlobal = globalThis as typeof globalThis & {
     claim: () => Promise<void>
   }
 }
-
-const isSameOriginRequest = (request: Request): boolean => new URL(request.url).origin === location.origin
-
-const isSymbolsManifest = (request: Request): boolean => {
-  const path = new URL(request.url).pathname
-  return /\/(?:www\/)?symbols\/manifest\.js$/i.test(path)
-}
-
-const isSymbolSvg = (request: Request): boolean => {
-  const path = new URL(request.url).pathname
-  return /\/(?:www\/)?symbols\/.+\.svg$/i.test(path)
-}
-
-const shouldCacheRequest = (request: Request): boolean => isSymbolsManifest(request) || isSymbolSvg(request)
 
 const cacheResponse = async (request: Request, response: Response): Promise<Response> => {
   if (!response.ok) return response
@@ -66,7 +54,7 @@ serviceWorkerGlobal.addEventListener('fetch', (event) => {
   const fetchEvent = event as FetchEventLike
   const request = fetchEvent.request
 
-  if (request.method !== 'GET' || !isSameOriginRequest(request) || !shouldCacheRequest(request)) return
+  if (!isCacheableSvgRequest(request, location.origin)) return
 
   fetchEvent.respondWith(cacheFirst(request))
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,15 @@ export interface JsonObject {
   [key: string]: JsonValue
 }
 
+export type ElectricalProjectProfile = {
+  standard: 'AREI'
+  edition: string
+  supplyVoltageV: number
+  phaseConfiguration: 'single-phase' | 'three-phase'
+  earthingSystem: 'TT' | 'TN' | 'IT' | 'unknown'
+  defaultPoles: number
+}
+
 export type ProjectInput = {
   name: string
   logoUrl?: string
@@ -30,6 +39,7 @@ export type ProjectInput = {
   }
   eanCode?: string
   mainFuseA?: number
+  electricalProfile?: ElectricalProjectProfile
 }
 
 export interface Project extends ProjectInput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export interface JsonObject {
 export type ElectricalProjectProfile = {
   standard: 'AREI'
   edition: string
+  distributor: string
+  supplyConfiguration: '1x230V+N' | '3x230V' | '3x400V+N' | 'other'
   supplyVoltageV: number
   phaseConfiguration: 'single-phase' | 'three-phase'
   earthingSystem: 'TT' | 'TN' | 'IT' | 'unknown'

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,24 @@ export type ElectricalProjectProfile = {
   phaseConfiguration: 'single-phase' | 'three-phase'
   earthingSystem: 'TT' | 'TN' | 'IT' | 'unknown'
   defaultPoles: number
+  boards?: ElectricalBoard[]
+}
+
+export type ElectricalBoard = {
+  id: string
+  name: string
+  parentBoardId?: string
+  rails: Array<{ id: string; name: string }>
+  mainDifferential?: DifferentialProtection
+  additionalDifferentials?: DifferentialProtection[]
+}
+
+export type DifferentialProtection = {
+  id: string
+  ratedCurrentA: number
+  sensitivityMa: number
+  poles: number
+  type?: 'AC' | 'A' | 'F' | 'B' | 'other'
 }
 
 export type ProjectInput = {

--- a/test/circuit-analysis.test.ts
+++ b/test/circuit-analysis.test.ts
@@ -37,6 +37,12 @@ test('groups floor-plan devices and ignores generated one-wire geometry', () => 
       { bindingId: 'B2', switches: 0, loads: 1 }
     ]
   )
+  assert.equal(analysis.groups[0].specification.circuitType, 'lighting')
+  assert.equal(analysis.groups[0].specification.breakerCurrentA, 16)
+  assert.equal(analysis.groups[0].specification.cableSectionMm2, 1.5)
+  assert.equal(analysis.groups[0].specification.breakerCurve, 'C')
+  assert.equal(analysis.groups[1].specification.breakerCurrentA, 20)
+  assert.equal(analysis.groups[1].specification.cableSectionMm2, 2.5)
 })
 
 test('reports incomplete and unknown circuit symbols', () => {

--- a/test/circuit-analysis.test.ts
+++ b/test/circuit-analysis.test.ts
@@ -92,6 +92,7 @@ test('prefers explicit electrical metadata and derives circuit specifications', 
     cableSectionMm2: 4,
     poles: 4,
     phaseConfiguration: 'three-phase',
+    breakerCurve: 'C',
     source: 'explicit',
     sources: {
       breakerCurrentA: 'entered', cableSectionMm2: 'entered', poles: 'entered', phaseConfiguration: 'entered'
@@ -220,6 +221,8 @@ test('keeps partially entered circuit specifications marked as suggested', () =>
 
   assert.equal(analysis.groups[0].specification.breakerCurrentA, 20)
   assert.equal(analysis.groups[0].specification.cableSectionMm2, 2.5)
+  assert.equal(analysis.groups[0].specification.poles, 2)
+  assert.equal(analysis.groups[0].specification.breakerCurve, 'C')
   assert.equal(analysis.groups[0].specification.source, 'suggested')
   assert.equal(analysis.groups[0].specification.sources.breakerCurrentA, 'entered')
   assert.equal(analysis.groups[0].specification.sources.cableSectionMm2, 'suggested')

--- a/test/circuit-analysis.test.ts
+++ b/test/circuit-analysis.test.ts
@@ -92,7 +92,10 @@ test('prefers explicit electrical metadata and derives circuit specifications', 
     cableSectionMm2: 4,
     poles: 4,
     phaseConfiguration: 'three-phase',
-    source: 'explicit'
+    source: 'explicit',
+    sources: {
+      breakerCurrentA: 'entered', cableSectionMm2: 'entered', poles: 'entered', phaseConfiguration: 'entered'
+    }
   })
 })
 
@@ -182,6 +185,38 @@ test('does not use a device rated current as its breaker current', () => {
 
   assert.equal(analysis.groups[0].specification.breakerCurrentA, 20)
   assert.equal(analysis.groups[0].specification.source, 'suggested')
+  assert.equal(analysis.groups[0].specification.sources.breakerCurrentA, 'suggested')
+})
+
+test('uses project phase and pole defaults with field-level provenance', () => {
+  const analysis = analyzeCircuits(
+    [symbol('lamp', 'A1', 'Lighting', 'symbols/Consumption appliances/Lighting.svg')],
+    { standard: 'AREI', edition: 'Book 1', supplyVoltageV: 400, phaseConfiguration: 'three-phase', earthingSystem: 'TT', defaultPoles: 4 }
+  )
+  assert.equal(analysis.groups[0].specification.phaseConfiguration, 'three-phase')
+  assert.equal(analysis.groups[0].specification.poles, 4)
+  assert.equal(analysis.groups[0].specification.sources.phaseConfiguration, 'project')
+  assert.equal(analysis.groups[0].specification.sources.poles, 'project')
+})
+
+test('keeps partially entered circuit specifications marked as suggested', () => {
+  const partiallyConfigured = {
+    ...symbol('socket', 'S1', 'Socket', 'symbols/Socket outlets/socket.svg'),
+    electrical: {
+      role: 'load' as const,
+      oneWireEligible: true,
+      circuitType: 'sockets' as const,
+      breakerCurrentA: 20
+    }
+  }
+
+  const analysis = analyzeCircuits([partiallyConfigured])
+
+  assert.equal(analysis.groups[0].specification.breakerCurrentA, 20)
+  assert.equal(analysis.groups[0].specification.cableSectionMm2, 2.5)
+  assert.equal(analysis.groups[0].specification.source, 'suggested')
+  assert.equal(analysis.groups[0].specification.sources.breakerCurrentA, 'entered')
+  assert.equal(analysis.groups[0].specification.sources.cableSectionMm2, 'suggested')
 })
 
 test('rejects conflicting explicit circuit specifications', () => {

--- a/test/circuit-analysis.test.ts
+++ b/test/circuit-analysis.test.ts
@@ -191,7 +191,7 @@ test('does not use a device rated current as its breaker current', () => {
 test('uses project phase and pole defaults with field-level provenance', () => {
   const analysis = analyzeCircuits(
     [symbol('lamp', 'A1', 'Lighting', 'symbols/Consumption appliances/Lighting.svg')],
-    { standard: 'AREI', edition: 'Book 1', supplyVoltageV: 400, phaseConfiguration: 'three-phase', earthingSystem: 'TT', defaultPoles: 4 }
+    { standard: 'AREI', edition: 'Book 1', distributor: 'Fluvius', supplyConfiguration: '3x400V+N', supplyVoltageV: 400, phaseConfiguration: 'three-phase', earthingSystem: 'TT', defaultPoles: 4 }
   )
   assert.equal(analysis.groups[0].specification.phaseConfiguration, 'three-phase')
   assert.equal(analysis.groups[0].specification.poles, 4)

--- a/test/circuit-analysis.test.ts
+++ b/test/circuit-analysis.test.ts
@@ -123,7 +123,13 @@ test('normalizes catalog electrical metadata and keeps legacy inference as fallb
       breakerCurrentA: 25,
       poles: undefined,
       phaseConfiguration: undefined,
-      cableSectionMm2: 2.5
+      cableSectionMm2: 2.5,
+      breakerCurve: undefined,
+      rcdSensitivityMa: undefined,
+      rcdType: undefined,
+      boardId: undefined,
+      railId: undefined,
+      notes: undefined
     }
   )
   assert.equal(electricalMetadataFromCatalog(undefined, 'Wall switch', 'symbols/Switches/general.svg').role, 'switch')

--- a/test/circuit-defaults.test.ts
+++ b/test/circuit-defaults.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { circuitDefaults } from '../src/native-app/circuit-defaults.js'
+
+test('uses Belgian residential defaults for lighting circuits', () => {
+  assert.deepEqual(circuitDefaults('lighting'), {
+    breakerCurrentA: 16,
+    cableSectionMm2: 1.5,
+    poles: 2,
+    phaseConfiguration: 'single-phase',
+    breakerCurve: 'C',
+    boardId: 'main',
+    railId: 'rail-1'
+  })
+})
+
+test('keeps higher-load defaults for socket circuits', () => {
+  const defaults = circuitDefaults('sockets')
+  assert.equal(defaults.breakerCurrentA, 20)
+  assert.equal(defaults.cableSectionMm2, 2.5)
+})

--- a/test/document-state.test.ts
+++ b/test/document-state.test.ts
@@ -31,3 +31,16 @@ test('rejects malformed document dimensions and paper presets', () => {
   assert.equal(asNativeState({ ...base, printMargin: -1 }), null)
   assert.equal(asNativeState({ ...base, paperPreset: 'letter' }), null)
 })
+
+test('restores stable generated source links used by incremental regeneration', () => {
+  const state = asNativeState({
+    version: 1,
+    shapes: [{
+      id: 'generated-load', kind: 'symbol', position: { x: 10, y: 20 }, name: 'Load', path: 'load.svg', scale: 1,
+      generationKey: 'device:floor-load-1', sourceLink: { kind: 'device', id: 'floor-load-1', role: 'load' }
+    }],
+    selectedId: null, paperPreset: 'a4-landscape', printMargin: 0, worldWidth: 1000, worldHeight: 1000
+  })
+  assert.equal(state?.shapes[0].generationKey, 'device:floor-load-1')
+  assert.deepEqual(state?.shapes[0].sourceLink, { kind: 'device', id: 'floor-load-1', role: 'load' })
+})

--- a/test/e2e/first-load.spec.ts
+++ b/test/e2e/first-load.spec.ts
@@ -6,4 +6,15 @@ test('first load without an open project shows Projects instead of an empty edit
   await expect(page).toHaveURL(/#!\/projects$/)
   await expect(page.locator('projects-field').getByRole('heading', { name: 'Projects' })).toBeVisible()
   await expect(page.locator('projects-field')).toContainText('Welcome to Cadle')
+
+  const welcome = page.locator('projects-field md-dialog.welcome-dialog')
+  await expect(welcome).toBeVisible()
+  await expect(welcome.getByText('Hello, welcome to Cadle')).toBeVisible()
+  await expect(welcome.getByRole('button', { name: 'Create project' })).toBeVisible()
+  await expect(welcome.getByRole('button', { name: 'Upload project' })).toBeVisible()
+  await welcome.getByRole('button', { name: 'Maybe later' }).click()
+  await expect(welcome).not.toBeVisible()
+
+  await page.reload()
+  await expect(page.locator('projects-field md-dialog.welcome-dialog')).not.toBeVisible()
 })

--- a/test/e2e/first-load.spec.ts
+++ b/test/e2e/first-load.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@playwright/test'
+
+test('first load without an open project shows Projects instead of an empty editor', async ({ page }) => {
+  await page.goto('/#!/native-draw')
+
+  await expect(page).toHaveURL(/#!\/projects$/)
+  await expect(page.locator('projects-field').getByRole('heading', { name: 'Projects' })).toBeVisible()
+  await expect(page.locator('projects-field')).toContainText('Welcome to Cadle')
+})

--- a/test/e2e/onewire-workflow.spec.ts
+++ b/test/e2e/onewire-workflow.spec.ts
@@ -50,6 +50,13 @@ test('create, draw, bind, validate, generate, reload, and export one-wire projec
   await breakerCurve.selectOption('D')
   await page.waitForTimeout(600)
 
+  await placeAndBind('Switch general symbol', 500, 'B1')
+  await placeAndBind('Lighting', 580, 'B1')
+  await expect(breakerCurrent).toHaveValue('16')
+  await expect(cableSection).toHaveValue('1.5')
+  await expect(poles).toHaveValue('2')
+  await expect(breakerCurve).toHaveValue('C')
+
   const validation = await page.locator('cadle-app').evaluate((element: any) => element.analyzeBindings())
   expect(validation.valid, JSON.stringify(validation)).toBe(true)
   expect(validation.groups[0].bindingId).toBe('A1')
@@ -65,6 +72,8 @@ test('create, draw, bind, validate, generate, reload, and export one-wire projec
   expect((generatedSvg.match(/data-shape-id=/g) ?? []).length).toBeGreaterThan(3)
   expect(generatedSvg).toContain('D25')
   expect(generatedSvg).toContain('4 mm²')
+  expect(generatedSvg).toContain('C16')
+  expect(generatedSvg).toContain('1.5 mm²')
 
   await page.reload()
   await expect(page).toHaveURL(/#!\/native-draw/)

--- a/test/e2e/onewire-workflow.spec.ts
+++ b/test/e2e/onewire-workflow.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test'
+
+test('create, draw, bind, validate, generate, reload, and export one-wire project', async ({ page }) => {
+  await page.goto('/#!/create-project')
+  const values: Record<string, string> = {
+    'Project name': 'E2E AREI project', 'Page name': 'Ground plan', 'Customer name': 'Ada',
+    'Customer last name': 'Tester', Name: 'E2E', 'Last name': 'Installer', Company: 'Cadle Test',
+    Street: 'Teststraat', 'House number': '1', 'Postal code': '1000', City: 'Brussel'
+  }
+  for (const [label, value] of Object.entries(values)) {
+    await page.locator(`md-outlined-text-field[label="${label}"] input`).fill(value)
+  }
+  await page.getByRole('button', { name: 'Create project' }).click()
+  await expect(page).toHaveURL(/#!\/native-draw/)
+
+  await page.getByRole('tab', { name: 'Symbols catalog' }).click()
+  const stage = page.locator('cadle-app svg.stage')
+  await expect(stage).toBeVisible()
+  const placeAndBind = async (query: string, x: number, bindingId: string) => {
+    const search = page.locator('catalog-element search-element input')
+    await search.fill(query)
+    await expect(page.locator('catalog-element .search-status')).toContainText(query)
+    const item = page.locator('catalog-element catalog-item').filter({ hasText: query }).first()
+    await expect(item).toBeVisible()
+    await item.click()
+    await stage.click({ position: { x, y: 220 } })
+    const binding = page.locator('object-pane input.native-binding-input')
+    await expect(binding).toBeVisible()
+    await binding.fill(bindingId)
+    await binding.press('Tab')
+    await page.waitForTimeout(450)
+  }
+
+  await placeAndBind('Switch general symbol', 260, 'A1')
+  await placeAndBind('Lighting', 420, 'A1')
+
+  const validation = await page.locator('cadle-app').evaluate((element: any) => element.analyzeBindings())
+  expect(validation.valid, JSON.stringify(validation)).toBe(true)
+  expect(validation.groups[0].bindingId).toBe('A1')
+
+  await page.locator('app-shell').evaluate((element: any) => element.generateAutoOneWireSchema())
+  await expect.poll(() => page.locator('app-shell').evaluate((element: any) => element.project?.pages?.[element.loadedPage]?.pageType)).toBe('onewire')
+  const generated = await page.locator('cadle-app').evaluate((element: any) => element.generateAutoOneWire())
+  expect(generated.generated, generated.message).toBe(true)
+  const generatedSvg = await page.locator('cadle-app').evaluate((element: any) => element.toSVG())
+  expect((generatedSvg.match(/data-shape-id=/g) ?? []).length).toBeGreaterThan(3)
+
+  await page.reload()
+  await expect(page).toHaveURL(/#!\/native-draw/)
+  const exportedSvg = await page.locator('cadle-app').evaluate((element: any) => element.toSVG())
+  expect(exportedSvg).toContain('<svg')
+  expect(exportedSvg.length).toBeGreaterThan(1000)
+})

--- a/test/e2e/onewire-workflow.spec.ts
+++ b/test/e2e/onewire-workflow.spec.ts
@@ -32,11 +32,30 @@ test('create, draw, bind, validate, generate, reload, and export one-wire projec
   }
 
   await placeAndBind('Switch general symbol', 260, 'A1')
-  await placeAndBind('Lighting', 420, 'A1')
+  await placeAndBind('Electrical wall outlet for floorplan', 420, 'A1')
+
+  const pane = page.locator('object-pane')
+  const breakerCurrent = pane.getByRole('spinbutton', { name: 'Breaker (A)' })
+  const cableSection = pane.getByRole('spinbutton', { name: 'Cable (mm²)' })
+  const poles = pane.getByRole('spinbutton', { name: 'Poles', exact: true })
+  const breakerCurve = pane.getByRole('combobox', { name: 'Breaker curve' })
+  await expect(breakerCurrent).toHaveValue('20')
+  await expect(cableSection).toHaveValue('2.5')
+  await expect(poles).toHaveValue('2')
+  await expect(breakerCurve).toHaveValue('C')
+  await breakerCurrent.fill('25')
+  await breakerCurrent.press('Tab')
+  await cableSection.fill('4')
+  await cableSection.press('Tab')
+  await breakerCurve.selectOption('D')
+  await page.waitForTimeout(600)
 
   const validation = await page.locator('cadle-app').evaluate((element: any) => element.analyzeBindings())
   expect(validation.valid, JSON.stringify(validation)).toBe(true)
   expect(validation.groups[0].bindingId).toBe('A1')
+  expect(validation.groups[0].specification.breakerCurrentA).toBe(25)
+  expect(validation.groups[0].specification.cableSectionMm2).toBe(4)
+  expect(validation.groups[0].specification.breakerCurve).toBe('D')
 
   await page.locator('app-shell').evaluate((element: any) => element.generateAutoOneWireSchema())
   await expect.poll(() => page.locator('app-shell').evaluate((element: any) => element.project?.pages?.[element.loadedPage]?.pageType)).toBe('onewire')
@@ -44,6 +63,8 @@ test('create, draw, bind, validate, generate, reload, and export one-wire projec
   expect(generated.generated, generated.message).toBe(true)
   const generatedSvg = await page.locator('cadle-app').evaluate((element: any) => element.toSVG())
   expect((generatedSvg.match(/data-shape-id=/g) ?? []).length).toBeGreaterThan(3)
+  expect(generatedSvg).toContain('D25')
+  expect(generatedSvg).toContain('4 mm²')
 
   await page.reload()
   await expect(page).toHaveURL(/#!\/native-draw/)

--- a/test/editor-controllers.test.ts
+++ b/test/editor-controllers.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { CanvasDocumentController } from '../src/native-app/controllers/canvas-document-controller.ts'
+import { OneWireController } from '../src/native-app/controllers/onewire-controller.ts'
+import { CatalogController } from '../src/native-app/controllers/catalog-controller.ts'
+import type { Shape } from '../src/native-draw/types.ts'
+
+const shape = (id: string): Shape => ({ id, kind: 'text', position: { x: 0, y: 0 }, text: id })
+
+test('canvas document controller retains only valid selection after replacement', () => {
+  const controller = new CanvasDocumentController()
+  controller.shapes = [shape('a'), shape('b')]
+  controller.selectedId = 'a'
+  controller.selectedIds = new Set(['a', 'b'])
+  controller.replaceShapes([shape('b')])
+  assert.equal(controller.selectedId, null)
+  assert.deepEqual([...controller.selectedIds], ['b'])
+})
+
+test('one-wire controller owns analysis and layout planning', () => {
+  const controller = new OneWireController()
+  const plan = controller.plan([{ family: 'A', circuitCount: 2 }], 500, 500)
+  assert.equal(plan.pageCount, 1)
+})
+
+test('catalog controller creates a detached selection draft', () => {
+  const controller = new CatalogController()
+  const source = [shape('a')]
+  const draft = controller.selectionDraft(source, ['a'])
+  assert.ok(draft)
+  assert.notEqual(draft?.shapes[0], source[0])
+})

--- a/test/electrical-profile.test.ts
+++ b/test/electrical-profile.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { normalizeElectricalProfile } from '../src/native-app/electrical-profile.ts'
+
+test('keeps distributor and Belgian supply configuration in the project profile', () => {
+  const profile = normalizeElectricalProfile({
+    standard: 'AREI',
+    edition: 'Book 1',
+    distributor: ' Fluvius ',
+    supplyConfiguration: '3x400V+N',
+    supplyVoltageV: 400,
+    phaseConfiguration: 'three-phase',
+    earthingSystem: 'TT',
+    defaultPoles: 4
+  })
+  assert.equal(profile.distributor, 'Fluvius')
+  assert.equal(profile.supplyConfiguration, '3x400V+N')
+})

--- a/test/electrical-profile.test.ts
+++ b/test/electrical-profile.test.ts
@@ -11,8 +11,13 @@ test('keeps distributor and Belgian supply configuration in the project profile'
     supplyVoltageV: 400,
     phaseConfiguration: 'three-phase',
     earthingSystem: 'TT',
-    defaultPoles: 4
+    defaultPoles: 4,
+    boards: [{
+      id: 'main', name: 'Main board', rails: [{ id: 'rail-1', name: 'Rail 1' }],
+      mainDifferential: { id: 'main-rcd', ratedCurrentA: 40, sensitivityMa: 300, poles: 4, type: 'A' }
+    }]
   })
   assert.equal(profile.distributor, 'Fluvius')
   assert.equal(profile.supplyConfiguration, '3x400V+N')
+  assert.equal(profile.boards?.[0].mainDifferential?.sensitivityMa, 300)
 })

--- a/test/onewire-layout-plan.test.ts
+++ b/test/onewire-layout-plan.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { planOneWireLayout } from '../src/native-app/layout/onewire-layout-plan.ts'
+
+test('moves wide circuit families to another rail before they collide', () => {
+  const plan = planOneWireLayout(
+    [{ family: 'A', circuitCount: 8 }, { family: 'B', circuitCount: 8 }, { family: 'C', circuitCount: 4 }],
+    { usableWidth: 500, usableHeight: 700, minBranchWidth: 200, railHeight: 300 }
+  )
+  assert.deepEqual(plan.placements.map(({ family, railIndex }) => ({ family, railIndex })), [
+    { family: 'A', railIndex: 0 }, { family: 'B', railIndex: 1 }, { family: 'C', railIndex: 0 }
+  ])
+  assert.equal(plan.pageCount, 2)
+})
+
+test('keeps compact families on one rail when slots are available', () => {
+  const plan = planOneWireLayout(
+    [{ family: 'A', circuitCount: 2 }, { family: 'B', circuitCount: 3 }],
+    { usableWidth: 600, usableHeight: 400, minBranchWidth: 200 }
+  )
+  assert.equal(plan.pageCount, 1)
+  assert.deepEqual(plan.placements.map((item) => item.slotIndex), [0, 1])
+})

--- a/test/onewire-layout.test.ts
+++ b/test/onewire-layout.test.ts
@@ -54,6 +54,10 @@ test('attaches a composed breaker to a selected one-wire bus', () => {
   )
   assert.ok(result.shapes.every((shape) => shape.bindingId === 'A1'))
   assert.equal(new Set(result.shapes.map((shape) => shape.groupId)).size, 1)
+  const breaker = result.shapes.find((shape) => shape.kind === 'symbol')
+  assert.deepEqual(breaker?.kind === 'symbol' ? breaker.symbolTextOverrides : null, {
+    'desc:nP': '2P', 'desc:n': '1N', 'desc:20A': '20A'
+  })
 
   const connector = result.shapes[0]
   assert.equal(connector.kind, 'line')

--- a/test/onewire-layout.test.ts
+++ b/test/onewire-layout.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ONE_WIRE_PRESETS } from '../src/native-app/constants.ts'
+import { buildOneWireCircuit } from '../src/native-app/layout/onewire-builder.ts'
+import { buildOneWireBreakerSection } from '../src/native-app/layout/onewire-helpers.ts'
+
+const idSequence = () => {
+  let value = 0
+  return () => `shape-${++value}`
+}
+
+test('builds a complete lighting circuit upward from its bus connection', () => {
+  const result = buildOneWireCircuit(
+    { x: 400, y: 700 },
+    'A1',
+    ONE_WIRE_PRESETS.lighting,
+    idSequence(),
+    80,
+    24
+  )
+
+  assert.equal(result.shapes.length, 11)
+  assert.equal(result.primarySelection.length, result.shapes.length)
+  assert.ok(result.shapes.some((shape) => shape.kind === 'symbol' && shape.name === 'Automaat'))
+  assert.ok(
+    result.shapes.some(
+      (shape) => shape.kind === 'line' && shape.start.x === 400 && shape.start.y === 700 && shape.bindingId === 'A1'
+    )
+  )
+  assert.ok(result.shapes.every((shape) => shape.bindingId === 'A1'))
+})
+
+test('attaches a composed breaker to a selected one-wire bus', () => {
+  const result = buildOneWireBreakerSection(700, 400, 'A1', 'A', {
+    nextShapeId: idSequence(),
+    oneWireComponentSymbol: () => ({
+      name: 'Automaat',
+      path: 'symbols/Protection devices/Automaat.svg'
+    }),
+    oneWireSymbolScale: () => 1,
+    symbolContentBounds: (shape) => ({
+      x: shape.position.x - 12,
+      y: shape.position.y - 12,
+      width: 24,
+      height: 24
+    }),
+    branchStroke: '#000000',
+    kamrailAttachOffset: 20
+  })
+
+  assert.deepEqual(
+    result.shapes.map((shape) => shape.kind),
+    ['line', 'symbol', 'text']
+  )
+  assert.ok(result.shapes.every((shape) => shape.bindingId === 'A1'))
+  assert.equal(new Set(result.shapes.map((shape) => shape.groupId)).size, 1)
+
+  const connector = result.shapes[0]
+  assert.equal(connector.kind, 'line')
+  if (connector.kind === 'line') {
+    assert.deepEqual(connector.start, { x: 400, y: 680 })
+    assert.deepEqual(connector.end, { x: 400, y: 700 })
+  }
+})

--- a/test/onewire-preflight.test.ts
+++ b/test/onewire-preflight.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { evaluateOneWirePreflight } from '../src/shell/onewire-preflight.ts'
+
+test('requires bound ground-plan circuits before one-wire generation', () => {
+  assert.deepEqual(evaluateOneWirePreflight({ totalGroups: 0, errorCount: 0, valid: false }), {
+    ready: false,
+    reason: 'empty',
+    message: 'Add electrical devices to the ground plan and assign circuit IDs such as A1 before generating.'
+  })
+})
+
+test('keeps the user on the ground plan while validation errors remain', () => {
+  const result = evaluateOneWirePreflight({ totalGroups: 2, errorCount: 1, valid: false })
+  assert.equal(result.ready, false)
+  if (!result.ready) assert.equal(result.reason, 'invalid')
+})
+
+test('allows a valid ground plan to proceed to one-wire generation', () => {
+  assert.deepEqual(evaluateOneWirePreflight({ totalGroups: 2, errorCount: 0, valid: true }), { ready: true })
+})

--- a/test/onewire-regeneration.test.ts
+++ b/test/onewire-regeneration.test.ts
@@ -20,7 +20,7 @@ test('preserves manually positioned generated objects by stable generation key',
   const result = reconcileGeneratedOneWire([previous], [fresh])
   assert.equal(result.preserved, 1)
   assert.deepEqual(result.shapes[0].kind === 'symbol' ? result.shapes[0].position : null, { x: 440, y: 100 })
-  assert.equal(result.shapes[0].id, 'new-id')
+  assert.equal(result.shapes[0].id, 'old-id')
 })
 
 test('reports added and removed generated source objects', () => {

--- a/test/onewire-regeneration.test.ts
+++ b/test/onewire-regeneration.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { reconcileGeneratedOneWire } from '../src/native-app/layout/onewire-regeneration.ts'
+import type { Shape } from '../src/native-draw/types.ts'
+
+const generatedSymbol = (id: string, key: string, x: number): Shape => ({
+  id,
+  kind: 'symbol',
+  position: { x, y: 100 },
+  name: 'Load',
+  path: 'load.svg',
+  scale: 1,
+  generationKey: key,
+  sourceLink: { kind: 'device', id: 'floor-device-1', role: 'load' }
+})
+
+test('preserves manually positioned generated objects by stable generation key', () => {
+  const previous = generatedSymbol('old-id', 'device:floor-device-1', 440)
+  const fresh = generatedSymbol('new-id', 'device:floor-device-1', 120)
+  const result = reconcileGeneratedOneWire([previous], [fresh])
+  assert.equal(result.preserved, 1)
+  assert.deepEqual(result.shapes[0].kind === 'symbol' ? result.shapes[0].position : null, { x: 440, y: 100 })
+  assert.equal(result.shapes[0].id, 'new-id')
+})
+
+test('reports added and removed generated source objects', () => {
+  const result = reconcileGeneratedOneWire(
+    [generatedSymbol('old', 'device:removed', 10)],
+    [generatedSymbol('new', 'device:added', 20)]
+  )
+  assert.deepEqual({ added: result.added, removed: result.removed, preserved: result.preserved }, { added: 1, removed: 1, preserved: 0 })
+})

--- a/test/page-operations.test.ts
+++ b/test/page-operations.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test'
 import { clonePageSchema } from '../src/shell/page-schema.ts'
 
 test('clones page schemas without sharing object references', () => {
-  const schema = { version: 'native-svg-1', objects: [{ id: 'one' }] }
+  const schema = { version: 'native-svg-1', objects: [{ id: 'one', kind: 'wall' }] }
   const cloned = clonePageSchema(schema, {
     includeWalls: true,
     outsideWallsOnly: false,
@@ -14,4 +14,26 @@ test('clones page schemas without sharing object references', () => {
   assert.deepEqual(cloned, schema)
   assert.notEqual(cloned, schema)
   assert.notEqual(cloned.objects, schema.objects)
+})
+
+test('filters page objects according to the selected clone options', () => {
+  const schema = {
+    version: 'native-svg-1',
+    objects: [
+      { id: 'wall', kind: 'wall' },
+      { id: 'door', kind: 'door' },
+      { id: 'socket', kind: 'symbol', electrical: { role: 'load' } }
+    ]
+  }
+  const cloned = clonePageSchema(schema, {
+    includeWalls: true,
+    outsideWallsOnly: false,
+    includeOpenings: false,
+    includeElectrical: true
+  })
+
+  assert.deepEqual(
+    cloned.objects.map((object) => (object as { id: string }).id),
+    ['wall', 'socket']
+  )
 })

--- a/test/selection-properties.test.ts
+++ b/test/selection-properties.test.ts
@@ -44,3 +44,17 @@ test('moves a selected shape by its visual center', () => {
 
   assert.deepEqual(updated?.[0].kind === 'symbol' ? updated[0].position : null, { x: 50, y: 60 })
 })
+
+test('updates and clears selected symbol electrical properties', () => {
+  const configured = { ...symbol('one'), electrical: { role: 'load' as const, oneWireEligible: true, breakerCurrentA: 16 } }
+  const context = { selectedIds: new Set(['one']), selectedId: 'one', groupedSelection: false }
+  const updated = updateSelectionProperties(
+    [configured],
+    { electrical: { breakerCurrentA: 20, cableSectionMm2: 2.5 } },
+    context
+  )
+  assert.equal(updated?.[0].kind === 'symbol' && updated[0].electrical?.breakerCurrentA, 20)
+  assert.equal(updated?.[0].kind === 'symbol' && updated[0].electrical?.cableSectionMm2, 2.5)
+  const cleared = updateSelectionProperties(updated ?? [], { electrical: { breakerCurrentA: null } }, context)
+  assert.equal(cleared?.[0].kind === 'symbol' && cleared[0].electrical?.breakerCurrentA, undefined)
+})

--- a/test/selection-properties.test.ts
+++ b/test/selection-properties.test.ts
@@ -50,11 +50,12 @@ test('updates and clears selected symbol electrical properties', () => {
   const context = { selectedIds: new Set(['one']), selectedId: 'one', groupedSelection: false }
   const updated = updateSelectionProperties(
     [configured],
-    { electrical: { breakerCurrentA: 20, cableSectionMm2: 2.5 } },
+    { electrical: { breakerCurrentA: 20, cableSectionMm2: 2.5, breakerCurve: 'C', rcdSensitivityMa: 30, boardId: 'main', railId: 'rail-1' } },
     context
   )
   assert.equal(updated?.[0].kind === 'symbol' && updated[0].electrical?.breakerCurrentA, 20)
   assert.equal(updated?.[0].kind === 'symbol' && updated[0].electrical?.cableSectionMm2, 2.5)
+  assert.equal(updated?.[0].kind === 'symbol' && updated[0].electrical?.rcdSensitivityMa, 30)
   const cleared = updateSelectionProperties(updated ?? [], { electrical: { breakerCurrentA: null } }, context)
   assert.equal(cleared?.[0].kind === 'symbol' && cleared[0].electrical?.breakerCurrentA, undefined)
 })

--- a/test/service-worker-cache-policy.test.ts
+++ b/test/service-worker-cache-policy.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { isCacheableSvgRequest } from '../src/service-worker/cache-policy.js'
+
+const origin = 'https://cadle.example'
+
+test('service worker caches only same-origin GET requests for SVG files', () => {
+  assert.equal(isCacheableSvgRequest(new Request(`${origin}/symbols/socket.svg`), origin), true)
+  assert.equal(isCacheableSvgRequest(new Request(`${origin}/assets/LOGO.SVG?version=2`), origin), true)
+  assert.equal(isCacheableSvgRequest(new Request(`${origin}/symbols/manifest.js`), origin), false)
+  assert.equal(isCacheableSvgRequest(new Request(`${origin}/app.js`), origin), false)
+  assert.equal(isCacheableSvgRequest(new Request('https://cdn.example/socket.svg'), origin), false)
+  assert.equal(isCacheableSvgRequest(new Request(`${origin}/symbols/socket.svg`, { method: 'POST' }), origin), false)
+})


### PR DESCRIPTION
## Summary
- block one-wire generation until the ground plan has valid bound circuits
- preserve circuit bindings in generated one-wire symbols and cover the layout with tests
- add an AREI-oriented project electrical profile for phase, voltage, earthing system, and pole defaults
- make circuit role, type, breaker, cable, poles, and phase editable from the object pane
- show field-level provenance so entered, project-default, and suggested values remain distinguishable

## Safety and scope
This is an AREI-oriented authoring aid, not a legal compliance certification. Suggested cable and protection values remain clearly marked and must be confirmed by the designer and authorised inspection.

## Verification
- npm run check
- 43 tests passing
- TypeScript typecheck
- production build